### PR TITLE
Fix small issue w/ Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,7 @@ steps:
         README.md
         Support\CI\PhotoDemon.exe
       targetFolder: '$(Build.BinariesDirectory)'
+      cleanTargetFolder: true
       
   - task: CopyFiles@2
     displayName: 'Copy App folder to $(Build.ArtifactStagingDirectory)\App'


### PR DESCRIPTION
Just found out `$(Build.BinariesDirectory)` (along w/ source directories) are not cleaned up by default for performance reasons and `CopyFiles@2` refuses to over-write already present files.

There is an alternative `overWrite: true` input parameter on `CopyFiles@2` that might do job as well.