### PR TITLE
Fix repetitive clicking skipping every other click for spinners

### DIFF
--- a/Controls/pdSpinner.ctl
+++ b/Controls/pdSpinner.ctl
@@ -503,6 +503,10 @@ Private Sub ucSupport_LostFocusAPI()
     RedrawBackBuffer
 End Sub
 
+Private Sub ucSupport_DoubleClickCustom(ByVal Button As PDMouseButtonConstants, ByVal Shift As ShiftConstants, ByVal x As Long, ByVal y As Long)
+    ucSupport_MouseDownCustom Button, Shift, x, y, 0
+End Sub
+
 Private Sub ucSupport_MouseDownCustom(ByVal Button As PDMouseButtonConstants, ByVal Shift As ShiftConstants, ByVal x As Long, ByVal y As Long, ByVal timeStamp As Long)
     
     'Determine mouse button state for the up and down button areas


### PR DESCRIPTION
This forwards dbl-click in `pdSpinner.ctl` to mouse-down impl to allow changing values w/ fast clicks on spinner's up/down buttons.

This might need more refactoring if mouse-down is to be extracted to a sub/function that can be called from dbl-click as well.