### PR TITLE
Add language override for Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,7 @@
 *.frx    -diff
 *.res    -diff
 *.RES    -diff
-*.bas    eol=crlf
+*.bas    eol=crlf linguist-language=Visual-Basic-6.0
 *.cls    eol=crlf
 *.ctl    eol=crlf
 *.frm    eol=crlf


### PR DESCRIPTION
Adding this will make sure that the language associated to `.bas` files is correct. (For more details : https://github.com/github/linguist/issues/5824#issuecomment-1274055186).