### PR TITLE
Added Japanese localization

### DIFF
--- a/App/PhotoDemon/Languages/Japanese.xml
+++ b/App/PhotoDemon/Languages/Japanese.xml
@@ -1,0 +1,13966 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+
+<pdData>
+
+<pdDataType>Translation</pdDataType>
+
+<langid>ja-JP</langid>
+<langname>日本語 (Japanese)</langname>
+<langversion>1.0.0</langversion>
+<langstatus>95% complete</langstatus>
+
+<author>Kenji Hoshimoto (Hosiken)</author>
+
+<!-- BEGIN AUTOMATIC TEXT GENERATION -->
+
+<phrase>
+<original>New image</original>
+<translation>新規画像</translation>
+</phrase>
+
+<phrase>
+<original>Open</original>
+<translation>開く</translation>
+</phrase>
+
+<phrase>
+<original>Paste to new image</original>
+<translation>新規画像に貼り付け</translation>
+</phrase>
+
+<phrase>
+<original>Scan image</original>
+<translation>画像をスキャン</translation>
+</phrase>
+
+<phrase>
+<original>Select scanner or camera</original>
+<translation>スキャナーかカメラを選択</translation>
+</phrase>
+
+<phrase>
+<original>Internet import</original>
+<translation>インターネット インポート</translation>
+</phrase>
+
+<phrase>
+<original>Screen capture</original>
+<translation>スクリーン キャプチャ</translation>
+</phrase>
+
+<phrase>
+<original>Close</original>
+<translation>閉じる</translation>
+</phrase>
+
+<phrase>
+<original>Close all</original>
+<translation>すべて閉じる</translation>
+</phrase>
+
+<phrase>
+<original>Save</original>
+<translation>保存</translation>
+</phrase>
+
+<phrase>
+<original>Save copy</original>
+<translation>コピーを保存</translation>
+</phrase>
+
+<phrase>
+<original>Save as</original>
+<translation>名前を付けて保存</translation>
+</phrase>
+
+<phrase>
+<original>Revert</original>
+<translation>差し戻す</translation>
+</phrase>
+
+<phrase>
+<original>Export animated GIF</original>
+<translation>アニメーションGIFでエクスポート</translation>
+</phrase>
+
+<phrase>
+<original>Export animated PNG</original>
+<translation>アニメーションPNGでエクスポート</translation>
+</phrase>
+
+<phrase>
+<original>Export animated WebP</original>
+<translation>アニメーションWebPでエクスポート</translation>
+</phrase>
+
+<phrase>
+<original>Export color lookup</original>
+<translation>カラー ルックアップをエクスポート</translation>
+</phrase>
+
+<phrase>
+<original>Export color profile</original>
+<translation>カラー プロファイルをエクスポート</translation>
+</phrase>
+
+<phrase>
+<original>Export palette</original>
+<translation>パレットをエクスポート</translation>
+</phrase>
+
+<phrase>
+<original>Batch wizard</original>
+<translation>バッチ ウィザード</translation>
+</phrase>
+
+<phrase>
+<original>Print</original>
+<translation>印刷</translation>
+</phrase>
+
+<phrase>
+<original>Exit program</original>
+<translation>プログラムを終了</translation>
+</phrase>
+
+<phrase>
+<original>Undo</original>
+<translation>元に戻す</translation>
+</phrase>
+
+<phrase>
+<original>Redo</original>
+<translation>やり直し</translation>
+</phrase>
+
+<phrase>
+<original>Undo history</original>
+<translation>作業履歴</translation>
+</phrase>
+
+<phrase>
+<original>Repeat last action</original>
+<translation>最後のアクションを繰り返し</translation>
+</phrase>
+
+<phrase>
+<original>Fade</original>
+<translation>フェード</translation>
+</phrase>
+
+<phrase>
+<original>Cut</original>
+<translation>切り取り</translation>
+</phrase>
+
+<phrase>
+<original>Cut merged</original>
+<translation>結合をカット</translation>
+</phrase>
+
+<phrase>
+<original>Copy</original>
+<translation>コピー</translation>
+</phrase>
+
+<phrase>
+<original>Copy merged</original>
+<translation>結合をコピー</translation>
+</phrase>
+
+<phrase>
+<original>Paste</original>
+<translation>貼り付け</translation>
+</phrase>
+
+<phrase>
+<original>Paste to cursor</original>
+<translation>カーソルに貼り付け</translation>
+</phrase>
+
+<phrase>
+<original>Cut special</original>
+<translation>特殊な切り取り</translation>
+</phrase>
+
+<phrase>
+<original>Copy special</original>
+<translation>特殊なコピー</translation>
+</phrase>
+
+<phrase>
+<original>Paste special</original>
+<translation>特殊な貼り付け</translation>
+</phrase>
+
+<phrase>
+<original>Empty clipboard</original>
+<translation>クリップボードを空にする</translation>
+</phrase>
+
+<phrase>
+<original>Clear</original>
+<translation>消去</translation>
+</phrase>
+
+<phrase>
+<original>Content-aware fill</original>
+<translation>コンテンツに応じた塗りつぶし</translation>
+</phrase>
+
+<phrase>
+<original>Fill</original>
+<translation>塗りつぶし</translation>
+</phrase>
+
+<phrase>
+<original>Stroke</original>
+<translation>ストローク</translation>
+</phrase>
+
+<phrase>
+<original>Duplicate image</original>
+<translation>画像を複製</translation>
+</phrase>
+
+<phrase>
+<original>Resize image</original>
+<translation>画像のリサイズ</translation>
+</phrase>
+
+<phrase>
+<original>Content-aware image resize</original>
+<translation>コンテンツに応じた画像リサイズ</translation>
+</phrase>
+
+<phrase>
+<original>Canvas size</original>
+<translation>キャンバスのサイズ</translation>
+</phrase>
+
+<phrase>
+<original>Fit canvas to active layer</original>
+<translation>キャンバスをアクティブ レイヤーに合わせる</translation>
+</phrase>
+
+<phrase>
+<original>Fit canvas around all layers</original>
+<translation>キャンバスをすべてのレイヤーに合わせる</translation>
+</phrase>
+
+<phrase>
+<original>Crop</original>
+<translation>切り抜き</translation>
+</phrase>
+
+<phrase>
+<original>Trim empty image borders</original>
+<translation>余白をトリミング</translation>
+</phrase>
+
+<phrase>
+<original>Straighten image</original>
+<translation>画像の傾き補正</translation>
+</phrase>
+
+<phrase>
+<original>Rotate image 90 clockwise</original>
+<translation>画像を時計回りに90度回転</translation>
+</phrase>
+
+<phrase>
+<original>Rotate image 90 counter-clockwise</original>
+<translation>画像を反時計回りに90度回転</translation>
+</phrase>
+
+<phrase>
+<original>Rotate image 180</original>
+<translation>画像を180度回転</translation>
+</phrase>
+
+<phrase>
+<original>Arbitrary image rotation</original>
+<translation>画像を任意の角度で回転</translation>
+</phrase>
+
+<phrase>
+<original>Flip image horizontally</original>
+<translation>画像を左右反転</translation>
+</phrase>
+
+<phrase>
+<original>Flip image vertically</original>
+<translation>画像を上下反転</translation>
+</phrase>
+
+<phrase>
+<original>Merge visible layers</original>
+<translation>表示レイヤーを統合</translation>
+</phrase>
+
+<phrase>
+<original>Flatten image</original>
+<translation>画像を統合</translation>
+</phrase>
+
+<phrase>
+<original>Animation options</original>
+<translation>アニメーション設定</translation>
+</phrase>
+
+<phrase>
+<original>Create color lookup</original>
+<translation>カラー ルックアップを作成</translation>
+</phrase>
+
+<phrase>
+<original>Compare similarity</original>
+<translation>類似性を比較</translation>
+</phrase>
+
+<phrase>
+<original>Edit metadata</original>
+<translation>メタデータを編集</translation>
+</phrase>
+
+<phrase>
+<original>Remove all metadata</original>
+<translation>すべてのメタデータを削除</translation>
+</phrase>
+
+<phrase>
+<original>Count unique colors</original>
+<translation>色数を数える</translation>
+</phrase>
+
+<phrase>
+<original>Add new layer</original>
+<translation>新規レイヤーを追加</translation>
+</phrase>
+
+<phrase>
+<original>Add blank layer</original>
+<translation>空のレイヤーを追加</translation>
+</phrase>
+
+<phrase>
+<original>Duplicate Layer</original>
+<translation>レイヤーを複製</translation>
+</phrase>
+
+<phrase>
+<original>New layer from file</original>
+<translation>ファイルから新規レイヤー</translation>
+</phrase>
+
+<phrase>
+<original>New layer from visible layers</original>
+<translation>表示レイヤーから新規レイヤー</translation>
+</phrase>
+
+<phrase>
+<original>Layer via copy</original>
+<translation>レイヤーをコピー</translation>
+</phrase>
+
+<phrase>
+<original>Layer via cut</original>
+<translation>レイヤーを切り取り</translation>
+</phrase>
+
+<phrase>
+<original>Delete layer</original>
+<translation>レイヤーを削除</translation>
+</phrase>
+
+<phrase>
+<original>Delete hidden layers</original>
+<translation>非表示のレイヤーを削除</translation>
+</phrase>
+
+<phrase>
+<original>Replace layer from clipboard</original>
+<translation>クリップボードからレイヤーを置換</translation>
+</phrase>
+
+<phrase>
+<original>Replace layer from file</original>
+<translation>ファイルからレイヤーを置換</translation>
+</phrase>
+
+<phrase>
+<original>Replace layer from visible layers</original>
+<translation>表示レイヤーからレイヤーを置換</translation>
+</phrase>
+
+<phrase>
+<original>Merge layer up</original>
+<translation>上のレイヤーと結合</translation>
+</phrase>
+
+<phrase>
+<original>Merge layer down</original>
+<translation>下のレイヤーと結合</translation>
+</phrase>
+
+<phrase>
+<original>Go to top layer</original>
+<translation>最上位レイヤーに移動</translation>
+</phrase>
+
+<phrase>
+<original>Go to layer above</original>
+<translation>上のレイヤーに移動</translation>
+</phrase>
+
+<phrase>
+<original>Go to layer below</original>
+<translation>下のレイヤーに移動</translation>
+</phrase>
+
+<phrase>
+<original>Go to bottom layer</original>
+<translation>一番下のレイヤーに移動</translation>
+</phrase>
+
+<phrase>
+<original>Raise layer to top</original>
+<translation>レイヤーを最前面へ</translation>
+</phrase>
+
+<phrase>
+<original>Raise layer</original>
+<translation>レイヤーを前面へ</translation>
+</phrase>
+
+<phrase>
+<original>Lower layer</original>
+<translation>レイヤーを背面へ</translation>
+</phrase>
+
+<phrase>
+<original>Lower layer to bottom</original>
+<translation>レイヤーを最背面へ</translation>
+</phrase>
+
+<phrase>
+<original>Reverse layer order</original>
+<translation>レイヤーの順序を逆にする</translation>
+</phrase>
+
+<phrase>
+<original>Toggle layer visibility</original>
+<translation>レイヤーの可視/不可視を切り替え</translation>
+</phrase>
+
+<phrase>
+<original>Show only this layer</original>
+<translation>このレイヤーのみ表示</translation>
+</phrase>
+
+<phrase>
+<original>Hide only this layer</original>
+<translation>このレイヤーのみ隠す</translation>
+</phrase>
+
+<phrase>
+<original>Show all layers</original>
+<translation>すべてのレイヤーを表示</translation>
+</phrase>
+
+<phrase>
+<original>Hide all layers</original>
+<translation>すべてのレイヤーを隠す</translation>
+</phrase>
+
+<phrase>
+<original>Crop layer to selection</original>
+<translation>レイヤーを選択範囲で切り抜き</translation>
+</phrase>
+
+<phrase>
+<original>Pad layer to image size</original>
+<translation>レイヤーを画像サイズに合わせる</translation>
+</phrase>
+
+<phrase>
+<original>Trim empty layer borders</original>
+<translation>レイヤーの余白をトリミング</translation>
+</phrase>
+
+<phrase>
+<original>Straighten layer</original>
+<translation>レイヤーの傾き補正</translation>
+</phrase>
+
+<phrase>
+<original>Rotate layer 90 clockwise</original>
+<translation>レイヤーを時計回りに90度回転</translation>
+</phrase>
+
+<phrase>
+<original>Rotate layer 90 counter-clockwise</original>
+<translation>レイヤーを反時計回りに90度回転</translation>
+</phrase>
+
+<phrase>
+<original>Rotate layer 180</original>
+<translation>レイヤーを180度回転</translation>
+</phrase>
+
+<phrase>
+<original>Arbitrary layer rotation</original>
+<translation>レイヤーを任意の角度で回転</translation>
+</phrase>
+
+<phrase>
+<original>Flip layer horizontally</original>
+<translation>レイヤーを左右反転</translation>
+</phrase>
+
+<phrase>
+<original>Flip layer vertically</original>
+<translation>レイヤーを上下反転</translation>
+</phrase>
+
+<phrase>
+<original>Reset layer size</original>
+<translation>レイヤーのサイズをリセット</translation>
+</phrase>
+
+<phrase>
+<original>Resize layer</original>
+<translation>レイヤーサイズの変更</translation>
+</phrase>
+
+<phrase>
+<original>Content-aware layer resize</original>
+<translation>コンテンツに応じたレイヤーのリサイズ</translation>
+</phrase>
+
+<phrase>
+<original>Fit layer to image</original>
+<translation>レイヤーを画像に合わせる</translation>
+</phrase>
+
+<phrase>
+<original>Color to alpha</original>
+<translation>色を透明度に</translation>
+</phrase>
+
+<phrase>
+<original>Luminance to alpha</original>
+<translation>輝度をアルファにする</translation>
+</phrase>
+
+<phrase>
+<original>Remove alpha channel</original>
+<translation>アルファ チャンネルを削除</translation>
+</phrase>
+
+<phrase>
+<original>Threshold alpha</original>
+<translation>アルファ チャンネルのしきい値</translation>
+</phrase>
+
+<phrase>
+<original>Rasterize layer</original>
+<translation>レイヤーをラスタライズ</translation>
+</phrase>
+
+<phrase>
+<original>Rasterize all layers</original>
+<translation>すべてのレイヤーをラスタライズ</translation>
+</phrase>
+
+<phrase>
+<original>Split layer into image</original>
+<translation>レイヤーを画像に分割</translation>
+</phrase>
+
+<phrase>
+<original>Split layers into images</original>
+<translation>レイヤーを画像に分割</translation>
+</phrase>
+
+<phrase>
+<original>Split images into layers</original>
+<translation>画像をレイヤーに分割</translation>
+</phrase>
+
+<phrase>
+<original>Select all</original>
+<translation>すべて選択</translation>
+</phrase>
+
+<phrase>
+<original>Remove selection</original>
+<translation>選択を解除</translation>
+</phrase>
+
+<phrase>
+<original>Invert selection</original>
+<translation>選択範囲を反転</translation>
+</phrase>
+
+<phrase>
+<original>Grow selection</original>
+<translation>選択範囲を拡張</translation>
+</phrase>
+
+<phrase>
+<original>Shrink selection</original>
+<translation>選択範囲を収縮</translation>
+</phrase>
+
+<phrase>
+<original>Border selection</original>
+<translation>縁取り選択</translation>
+</phrase>
+
+<phrase>
+<original>Feather selection</original>
+<translation>選択範囲の境界をぼかす</translation>
+</phrase>
+
+<phrase>
+<original>Sharpen selection</original>
+<translation>選択範囲の境界を明確化</translation>
+</phrase>
+
+<phrase>
+<original>Erase selected area</original>
+<translation>選択範囲を消去</translation>
+</phrase>
+
+<phrase>
+<original>Fill selected area</original>
+<translation>選択範囲を塗りつぶし</translation>
+</phrase>
+
+<phrase>
+<original>Heal selected area</original>
+<translation>選択範囲内を修正</translation>
+</phrase>
+
+<phrase>
+<original>Stroke selection outline</original>
+<translation>選択範囲の境界を描く</translation>
+</phrase>
+
+<phrase>
+<original>Load selection</original>
+<translation>選択範囲を読み込み</translation>
+</phrase>
+
+<phrase>
+<original>Save selection</original>
+<translation>選択範囲を保存</translation>
+</phrase>
+
+<phrase>
+<original>Export selected area as image</original>
+<translation>選択範囲を画像としてエクスポート</translation>
+</phrase>
+
+<phrase>
+<original>Export selection mask as image</original>
+<translation>選択マスクを画像としてエクスポート</translation>
+</phrase>
+
+<phrase>
+<original>Auto correct</original>
+<translation>自動修正</translation>
+</phrase>
+
+<phrase>
+<original>Auto enhance</original>
+<translation>自動エンハンス</translation>
+</phrase>
+
+<phrase>
+<original>Black and white</original>
+<translation>モノクロ</translation>
+</phrase>
+
+<phrase>
+<original>Brightness and contrast</original>
+<translation>明るさとコントラスト</translation>
+</phrase>
+
+<phrase>
+<original>Color balance</original>
+<translation>カラー バランス</translation>
+</phrase>
+
+<phrase>
+<original>Curves</original>
+<translation>トーン カーブ</translation>
+</phrase>
+
+<phrase>
+<original>Levels</original>
+<translation>レベル</translation>
+</phrase>
+
+<phrase>
+<original>Shadows and highlights</original>
+<translation>シャドウとハイライト</translation>
+</phrase>
+
+<phrase>
+<original>Vibrance</original>
+<translation>自然な彩度</translation>
+</phrase>
+
+<phrase>
+<original>White balance</original>
+<translation>ホワイト バランス</translation>
+</phrase>
+
+<phrase>
+<original>Channel mixer</original>
+<translation>チャンネ ルミキサー</translation>
+</phrase>
+
+<phrase>
+<original>Rechannel</original>
+<translation>リチャンネル</translation>
+</phrase>
+
+<phrase>
+<original>Maximum channel</original>
+<translation>最大チャンネル</translation>
+</phrase>
+
+<phrase>
+<original>Minimum channel</original>
+<translation>最小チャンネル</translation>
+</phrase>
+
+<phrase>
+<original>Shift colors (left)</original>
+<translation>シフトカラー (左)</translation>
+</phrase>
+
+<phrase>
+<original>Shift colors (right)</original>
+<translation>シフトカラー (右)</translation>
+</phrase>
+
+<phrase>
+<original>Hue and saturation</original>
+<translation>色相と彩度</translation>
+</phrase>
+
+<phrase>
+<original>Temperature</original>
+<translation>色温度</translation>
+</phrase>
+
+<phrase>
+<original>Tint</original>
+<translation>色合い</translation>
+</phrase>
+
+<phrase>
+<original>Color lookup</original>
+<translation>カラー ルックアップ</translation>
+</phrase>
+
+<phrase>
+<original>Colorize</original>
+<translation>着色</translation>
+</phrase>
+
+<phrase>
+<original>Photo filter</original>
+<translation>フォト フィルター</translation>
+</phrase>
+
+<phrase>
+<original>Replace color</original>
+<translation>色を置換</translation>
+</phrase>
+
+<phrase>
+<original>Sepia</original>
+<translation>セピア</translation>
+</phrase>
+
+<phrase>
+<original>Split toning</original>
+<translation>トーニングを分割</translation>
+</phrase>
+
+<phrase>
+<original>Equalize</original>
+<translation>平滑化</translation>
+</phrase>
+
+<phrase>
+<original>Stretch histogram</original>
+<translation>ヒストグラムを伸張</translation>
+</phrase>
+
+<phrase>
+<original>Film negative</original>
+<translation>フィルムネガ</translation>
+</phrase>
+
+<phrase>
+<original>Invert hue</original>
+<translation>色相を反転させる</translation>
+</phrase>
+
+<phrase>
+<original>Invert RGB</original>
+<translation>Rgb反転</translation>
+</phrase>
+
+<phrase>
+<original>Dehaze</original>
+<translation>デヘイズ</translation>
+</phrase>
+
+<phrase>
+<original>Exposure</original>
+<translation>露出</translation>
+</phrase>
+
+<phrase>
+<original>Gamma</original>
+<translation>ガンマ</translation>
+</phrase>
+
+<phrase>
+<original>HDR</original>
+<translation>HDR</translation>
+</phrase>
+
+<phrase>
+<original>Gradient map</original>
+<translation>グラデーション マップ</translation>
+</phrase>
+
+<phrase>
+<original>Palette map</original>
+<translation>パレット マップ</translation>
+</phrase>
+
+<phrase>
+<original>Color to monochrome</original>
+<translation>カラーからモノクロへ</translation>
+</phrase>
+
+<phrase>
+<original>Monochrome to gray</original>
+<translation>モノクロからグレーへ</translation>
+</phrase>
+
+<phrase>
+<original>Colored pencil</original>
+<translation>色鉛筆</translation>
+</phrase>
+
+<phrase>
+<original>Comic book</original>
+<translation>コミック</translation>
+</phrase>
+
+<phrase>
+<original>Figured glass</original>
+<translation>フィギュアドグラス</translation>
+</phrase>
+
+<phrase>
+<original>Film noir</original>
+<translation>フィルム・ノワール</translation>
+</phrase>
+
+<phrase>
+<original>Glass tiles</original>
+<translation>ガラスタイル</translation>
+</phrase>
+
+<phrase>
+<original>Kaleidoscope</original>
+<translation>万華鏡</translation>
+</phrase>
+
+<phrase>
+<original>Modern art</original>
+<translation>モダンアート</translation>
+</phrase>
+
+<phrase>
+<original>Oil painting</original>
+<translation>油絵</translation>
+</phrase>
+
+<phrase>
+<original>Plastic wrap</original>
+<translation>ラップ</translation>
+</phrase>
+
+<phrase>
+<original>Posterize</original>
+<translation>ポスタリゼーション</translation>
+</phrase>
+
+<phrase>
+<original>Relief</original>
+<translation>リレーフ</translation>
+</phrase>
+
+<phrase>
+<original>Stained glass</original>
+<translation>ステンド グラス</translation>
+</phrase>
+
+<phrase>
+<original>Box blur</original>
+<translation>ボックスぼかし</translation>
+</phrase>
+
+<phrase>
+<original>Gaussian blur</original>
+<translation>ガウスぼかし</translation>
+</phrase>
+
+<phrase>
+<original>Surface blur</original>
+<translation>ぼかし</translation>
+</phrase>
+
+<phrase>
+<original>Motion blur</original>
+<translation>モーションぼかし</translation>
+</phrase>
+
+<phrase>
+<original>Radial blur</original>
+<translation>円形ぼかし</translation>
+</phrase>
+
+<phrase>
+<original>Zoom blur</original>
+<translation>ズームぼかし</translation>
+</phrase>
+
+<phrase>
+<original>Correct lens distortion</original>
+<translation>レンズ歪みの補正</translation>
+</phrase>
+
+<phrase>
+<original>Donut</original>
+<translation>ドーナツ</translation>
+</phrase>
+
+<phrase>
+<original>Droste</original>
+<translation>ドロステ</translation>
+</phrase>
+
+<phrase>
+<original>Apply lens distortion</original>
+<translation>レンズ ディストーションを適用</translation>
+</phrase>
+
+<phrase>
+<original>Pinch and whirl</original>
+<translation>つまんで回す</translation>
+</phrase>
+
+<phrase>
+<original>Poke</original>
+<translation>ポーク</translation>
+</phrase>
+
+<phrase>
+<original>Ripple</original>
+<translation>波紋</translation>
+</phrase>
+
+<phrase>
+<original>Squish</original>
+<translation>つぶれ</translation>
+</phrase>
+
+<phrase>
+<original>Swirl</original>
+<translation>渦巻き</translation>
+</phrase>
+
+<phrase>
+<original>Waves</original>
+<translation>波</translation>
+</phrase>
+
+<phrase>
+<original>Miscellaneous distort</original>
+<translation>雑多な歪み</translation>
+</phrase>
+
+<phrase>
+<original>Emboss</original>
+<translation>エンボス</translation>
+</phrase>
+
+<phrase>
+<original>Enhance edges</original>
+<translation>エッジを強調</translation>
+</phrase>
+
+<phrase>
+<original>Find edges</original>
+<translation>エッジ検出</translation>
+</phrase>
+
+<phrase>
+<original>Gradient flow</original>
+<translation>勾配流</translation>
+</phrase>
+
+<phrase>
+<original>Range filter</original>
+<translation>レンジ フィルター</translation>
+</phrase>
+
+<phrase>
+<original>Trace contour</original>
+<translation>輪郭検出</translation>
+</phrase>
+
+<phrase>
+<original>Black light</original>
+<translation>ブラック ライト</translation>
+</phrase>
+
+<phrase>
+<original>Bump map</original>
+<translation>バンプ マップ</translation>
+</phrase>
+
+<phrase>
+<original>Cross-screen</original>
+<translation>クロス スクリーン</translation>
+</phrase>
+
+<phrase>
+<original>Rainbow</original>
+<translation>虹</translation>
+</phrase>
+
+<phrase>
+<original>Sunshine</original>
+<translation>日照</translation>
+</phrase>
+
+<phrase>
+<original>Dilate (maximum rank)</original>
+<translation>広げる (最高ランク)</translation>
+</phrase>
+
+<phrase>
+<original>Erode (minimum rank)</original>
+<translation>浸食浸食 (最低ランク)</translation>
+</phrase>
+
+<phrase>
+<original>Atmosphere</original>
+<translation>大気</translation>
+</phrase>
+
+<phrase>
+<original>Fog</original>
+<translation>霧</translation>
+</phrase>
+
+<phrase>
+<original>Ignite</original>
+<translation>発火</translation>
+</phrase>
+
+<phrase>
+<original>Lava</original>
+<translation>溶岩</translation>
+</phrase>
+
+<phrase>
+<original>Metal</original>
+<translation>メタル</translation>
+</phrase>
+
+<phrase>
+<original>Snow</original>
+<translation>雪</translation>
+</phrase>
+
+<phrase>
+<original>Water</original>
+<translation>水</translation>
+</phrase>
+
+<phrase>
+<original>Add film grain</original>
+<translation>フィルム グレインを加える</translation>
+</phrase>
+
+<phrase>
+<original>Add RGB noise</original>
+<translation>RGB ノイズを加える</translation>
+</phrase>
+
+<phrase>
+<original>Anisotropic diffusion</original>
+<translation>異方性拡散</translation>
+</phrase>
+
+<phrase>
+<original>Dust and scratches</original>
+<translation>埃と傷</translation>
+</phrase>
+
+<phrase>
+<original>Harmonic mean</original>
+<translation>調和平均</translation>
+</phrase>
+
+<phrase>
+<original>Mean shift</original>
+<translation>平均シフト</translation>
+</phrase>
+
+<phrase>
+<original>Median</original>
+<translation>中心値</translation>
+</phrase>
+
+<phrase>
+<original>Symmetric nearest-neighbor</original>
+<translation>対称ニアレスト ネイバー</translation>
+</phrase>
+
+<phrase>
+<original>Color halftone</original>
+<translation>カラー ハーフトーン</translation>
+</phrase>
+
+<phrase>
+<original>Crystallize</original>
+<translation>結晶化</translation>
+</phrase>
+
+<phrase>
+<original>Fragment</original>
+<translation>断片</translation>
+</phrase>
+
+<phrase>
+<original>Mezzotint</original>
+<translation>メゾチント</translation>
+</phrase>
+
+<phrase>
+<original>Mosaic</original>
+<translation>モザイク</translation>
+</phrase>
+
+<phrase>
+<original>Pointillize</original>
+<translation>ポインティライズ</translation>
+</phrase>
+
+<phrase>
+<original>Clouds</original>
+<translation>雲</translation>
+</phrase>
+
+<phrase>
+<original>Fibers</original>
+<translation>繊維</translation>
+</phrase>
+
+<phrase>
+<original>Truchet</original>
+<translation>トルシェ</translation>
+</phrase>
+
+<phrase>
+<original>Sharpen</original>
+<translation>境界の明確化</translation>
+</phrase>
+
+<phrase>
+<original>Unsharp mask</original>
+<translation>アンシャープマスク</translation>
+</phrase>
+
+<phrase>
+<original>Antique</original>
+<translation>アンティーク</translation>
+</phrase>
+
+<phrase>
+<original>Diffuse</original>
+<translation>拡散</translation>
+</phrase>
+
+<phrase>
+<original>Kuwahara filter</original>
+<translation>桑原フィルター</translation>
+</phrase>
+
+<phrase>
+<original>Outline</original>
+<translation>境界線</translation>
+</phrase>
+
+<phrase>
+<original>Palette</original>
+<translation>パレット</translation>
+</phrase>
+
+<phrase>
+<original>Portrait glow</original>
+<translation>肖像画の輝き</translation>
+</phrase>
+
+<phrase>
+<original>Solarize</original>
+<translation>ソラリゼーション</translation>
+</phrase>
+
+<phrase>
+<original>Twins</original>
+<translation>双子</translation>
+</phrase>
+
+<phrase>
+<original>Vignetting</original>
+<translation>口径食</translation>
+</phrase>
+
+<phrase>
+<original>Offset and zoom</original>
+<translation>オフセットとズーム</translation>
+</phrase>
+
+<phrase>
+<original>Perspective</original>
+<translation>遠近法</translation>
+</phrase>
+
+<phrase>
+<original>Polar conversion</original>
+<translation>極座標変換</translation>
+</phrase>
+
+<phrase>
+<original>Rotate</original>
+<translation>回転</translation>
+</phrase>
+
+<phrase>
+<original>Shear</original>
+<translation>剪断変形</translation>
+</phrase>
+
+<phrase>
+<original>Spherize</original>
+<translation>球面化</translation>
+</phrase>
+
+<phrase>
+<original>Animation background</original>
+<translation>アニメーションの背景</translation>
+</phrase>
+
+<phrase>
+<original>Animation foreground</original>
+<translation>アニメーションの前景</translation>
+</phrase>
+
+<phrase>
+<original>Animation playback speed</original>
+<translation>アニメーション再生速度</translation>
+</phrase>
+
+<phrase>
+<original>Custom filter</original>
+<translation>カスタム フィルタ</translation>
+</phrase>
+
+<phrase>
+<original>Photoshop (8bf) plugin</original>
+<translation>Photoshop (8bf) プラグイン</translation>
+</phrase>
+
+<phrase>
+<original>Start macro recording</original>
+<translation>マクロを記録開始</translation>
+</phrase>
+
+<phrase>
+<original>Stop macro recording</original>
+<translation>マクロの記録停止</translation>
+</phrase>
+
+<phrase>
+<original>Play macro</original>
+<translation>マクロを再生</translation>
+</phrase>
+
+<phrase>
+<original>Checking for software updates</original>
+<translation>ソフトウェアの更新を確認</translation>
+</phrase>
+
+<phrase>
+<original>File</original>
+<translation>ファイル</translation>
+</phrase>
+
+<phrase>
+<original>Open all recent images</original>
+<translation>最近使った画像をすべて開く</translation>
+</phrase>
+
+<phrase>
+<original>Clear recent image list</original>
+<translation>最近使った画像リストの消去</translation>
+</phrase>
+
+<!-- Actions.bas contains 271 phrases. 7 were duplicates of existing phrases, so only 264 new phrases were written to file. -->
+
+<phrase>
+<original>[untitled image]</original>
+<translation>[無題の画像]</translation>
+</phrase>
+
+<!-- Animation.bas contains 2 phrases.  One was a duplicate of an existing phrase, so only 1 new phrases were written to file. -->
+
+<phrase>
+<original>Autosave reconstruction complete for %1</original>
+<translation>%1 の自動保存の再構築が完了しました</translation>
+</phrase>
+
+<phrase>
+<original>Autosave could not be fully reconstructed.  Partial reconstruction attempted instead.</original>
+<translation>自動セーブを完全に再構築できませんでした。  かわりに部分的な再構築が試みられました。</translation>
+</phrase>
+
+<!-- AutosaveEngine.bas contains 2 phrases.  Both phrases were unique, so 2 new phrases were written to file. -->
+
+<phrase>
+<original>Unloading image %1 of %2</original>
+<translation>%2 個中 %1 個目の画像をアンロードしています</translation>
+</phrase>
+
+<phrase>
+<original>Closing image</original>
+<translation>画像を閉じる</translation>
+</phrase>
+
+<phrase>
+<original>Finished.</original>
+<translation>終了しました。</translation>
+</phrase>
+
+<!-- CanvasManager.bas contains 4 phrases.  One was a duplicate of an existing phrase, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>ICC profile</original>
+<translation>ICCプロファイル</translation>
+</phrase>
+
+<phrase>
+<original>New color profile</original>
+<translation>新しいカラー プロファイル</translation>
+</phrase>
+
+<phrase>
+<original>Profile exported successfully.</original>
+<translation>プロファイルは正常にエクスポートされました。</translation>
+</phrase>
+
+<!-- ColorManagement_ICM.bas contains 7 phrases. 4 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>How would you like to load this image?</original>
+<translation>この画像をどのように読み込みますか?</translation>
+</phrase>
+
+<phrase>
+<original>Open it as a standalone image.</original>
+<translation>単独の画像として開く。</translation>
+</phrase>
+
+<phrase>
+<original>Add it to the current image as a new layer.</original>
+<translation>新規レイヤーとして現在の画像に追加します。</translation>
+</phrase>
+
+<phrase>
+<original>I can't decide.  Cancel this action.</original>
+<translation>決められない。 このアクションをキャンセルする。</translation>
+</phrase>
+
+<phrase>
+<original>in the future, do this without asking me</original>
+<translation>今後、確認しない</translation>
+</phrase>
+
+<phrase>
+<original>Drop as image or layer</original>
+<translation>画像またはレイヤーとしてドロップ</translation>
+</phrase>
+
+<!-- DialogManager.bas contains 15 phrases. 9 were duplicates of existing phrases, so only 6 new phrases were written to file. -->
+
+<!-- EffectPrep.bas contains 1 phrase.  One was a duplicate of an existing phrase, so only 0 new phrases were written to file. -->
+
+<phrase>
+<original>ExifTool could not be started.  Metadata unavailable for this session.</original>
+<translation>ExifTool を起動できませんでした。  このセッションではメタデータを使用できません。</translation>
+</phrase>
+
+<phrase>
+<original>Please wait while the tag database is created</original>
+<translation>タグ データベースが作成されるまでお待ちください</translation>
+</phrase>
+
+<phrase>
+<original>The tag database handles technical details of the 20,000+ metadata tags supported by PhotoDemon.  Creating the database takes 10 to 15 seconds, and it only needs to be created once, when the metadata editor is used for the first time.</original>
+<translation>タグ データベースは、PhotoDemon がサポートする 20,000 以上のメタデータ タグの技術的な詳細を処理します。  データベースの作成は 10 秒から 15 秒かかり、メタデータ エディタが初めて使用されるときに、一度だけ作成する必要があります。</translation>
+</phrase>
+
+<phrase>
+<original>No metadata available</original>
+<translation>メタデータなし</translation>
+</phrase>
+
+<phrase>
+<original>This image does not contain metadata.</original>
+<translation>この画像にはメタデータが含まれていません。</translation>
+</phrase>
+
+<!-- Plugin_ExifTool.bas contains 9 phrases. 4 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<phrase>
+<original>Open an image</original>
+<translation>画像を開く</translation>
+</phrase>
+
+<phrase>
+<original>Select an image</original>
+<translation>画像を選択</translation>
+</phrase>
+
+<phrase>
+<original>Save an image</original>
+<translation>画像を保存</translation>
+</phrase>
+
+<phrase>
+<original>Before lossless copies can be saved, you must save this image at least once.
+
+Lossless copies will be saved to the same folder as this initial image save.</original>
+<translation>ロスレス コピーを保存する前に、少なくとも一度はこの画像を保存する必要があります。
+
+ロスレス コピーは、この最初の画像保存と同じフォルダに保存されます。</translation>
+</phrase>
+
+<phrase>
+<original>Initial save required</original>
+<translation>初期セーブが必要</translation>
+</phrase>
+
+<phrase>
+<original>Save canceled.</original>
+<translation>キャンセルされました。</translation>
+</phrase>
+
+<phrase>
+<original>An unspecified error occurred when attempting to save this image.  Please try saving the image to an alternate format.
+
+If the problem persists, please report it to the PhotoDemon developers via PhotoDemon.org/contact</original>
+<translation>この画像を保存しようとすると、特定できないエラーが発生しました。  別の形式で画像を保存してみてください。
+
+問題が解決しない場合、PhotoDemon.org/contact 経由で PhotoDemon 開発者に報告してください。</translation>
+</phrase>
+
+<phrase>
+<original>Error</original>
+<translation>エラー</translation>
+</phrase>
+
+<phrase>
+<original>background</original>
+<translation>背景</translation>
+</phrase>
+
+<phrase>
+<original>Original image</original>
+<translation>元の画像</translation>
+</phrase>
+
+<phrase>
+<original>Unfortunately, this PC does not have enough memory to create a %1x%2 image.  Please reduce the requested size and try again.</original>
+<translation>残念ながら、この PC には %1x%2 の画像を作成するのに十分なメモリがありません。  要求されたサイズを小さくして再試行してください。</translation>
+</phrase>
+
+<phrase>
+<original>Image too large</original>
+<translation>画像が大きすぎます</translation>
+</phrase>
+
+<!-- FileMenu.bas contains 23 phrases. 11 were duplicates of existing phrases, so only 12 new phrases were written to file. -->
+
+<phrase>
+<original>Auto-correcting colors and lighting</original>
+<translation>色と照明の自動補正</translation>
+</phrase>
+
+<phrase>
+<original>Adjusting image white balance</original>
+<translation>画像のホワイトバランスを調整</translation>
+</phrase>
+
+<phrase>
+<original>Inverting</original>
+<translation>反転</translation>
+</phrase>
+
+<phrase>
+<original>Shifting RGB values</original>
+<translation>RGB値のシフト</translation>
+</phrase>
+
+<phrase>
+<original>Calculating film negative values</original>
+<translation>フィルムのネガ値の計算</translation>
+</phrase>
+
+<phrase>
+<original>Isolating maximum color channels</original>
+<translation>最大カラーチャンネルの分離</translation>
+</phrase>
+
+<phrase>
+<original>Isolating minimum color channels</original>
+<translation>最小カラーチャンネルの分離</translation>
+</phrase>
+
+<phrase>
+<original>Auto-enhancing color and lighting</original>
+<translation>色と照明の自動補正</translation>
+</phrase>
+
+<!-- Filters_Color.bas contains 9 phrases.  One was a duplicate of an existing phrase, so only 8 new phrases were written to file. -->
+
+<phrase>
+<original>Applying %1 filter</original>
+<translation>%1 フィルタの適用</translation>
+</phrase>
+
+<phrase>
+<original>Generating grids</original>
+<translation>グリッドの生成</translation>
+</phrase>
+
+<phrase>
+<original>Applying grid blur</original>
+<translation>グリッド ブラーの適用</translation>
+</phrase>
+
+<!-- Filters_Area.bas contains 3 phrases.  All 3 were unique, so 3 new phrases were written to file. -->
+
+<phrase>
+<original>Counting the number of unique colors in this image</original>
+<translation>この画像に含まれる固有の色の数を数える</translation>
+</phrase>
+
+<phrase>
+<original>Total colors: %1</original>
+<translation>色の合計: %1</translation>
+</phrase>
+
+<phrase>
+<original>This image contains %1 unique colors (RGB).
+
+This image contains %2 unique color + opacity values (RGBA).</original>
+<translation>この画像には、固有の %1 色 (RGB) が含まれています。
+
+この画像には、固有の %2 色と不透明度の値 (RGBA) が含まれています。</translation>
+</phrase>
+
+<!-- Filters_Misc.bas contains 4 phrases.  One was a duplicate of an existing phrase, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>random</original>
+<translation>ランダム</translation>
+</phrase>
+
+<phrase>
+<original>image</original>
+<translation>画像</translation>
+</phrase>
+
+<phrase>
+<original>repeat</original>
+<translation>繰り返し</translation>
+</phrase>
+
+<phrase>
+<original>waves</original>
+<translation>波浪</translation>
+</phrase>
+
+<phrase>
+<original>quilt</original>
+<translation>キルト</translation>
+</phrase>
+
+<phrase>
+<original>chain</original>
+<translation>チェーン</translation>
+</phrase>
+
+<phrase>
+<original>weave</original>
+<translation>織</translation>
+</phrase>
+
+<phrase>
+<original>arc</original>
+<translation>円弧</translation>
+</phrase>
+
+<phrase>
+<original>line</original>
+<translation>ライン</translation>
+</phrase>
+
+<phrase>
+<original>maze</original>
+<translation>迷路</translation>
+</phrase>
+
+<phrase>
+<original>triangle</original>
+<translation>三角形</translation>
+</phrase>
+
+<phrase>
+<original>octagon</original>
+<translation>八角形</translation>
+</phrase>
+
+<phrase>
+<original>circle</original>
+<translation>円</translation>
+</phrase>
+
+<!-- Filters_Render.bas contains 26 phrases. 13 were duplicates of existing phrases, so only 13 new phrases were written to file. -->
+
+<phrase>
+<original>Time taken</original>
+<translation>所要時間</translation>
+</phrase>
+
+<!-- Filters_Scientific.bas contains 2 phrases.  One was a duplicate of an existing phrase, so only 1 new phrases were written to file. -->
+
+<phrase>
+<original>Analyzing image</original>
+<translation>画像の分析</translation>
+</phrase>
+
+<phrase>
+<original>Image is all one color.  Autocrop unnecessary.</original>
+<translation>画像はすべて1色。  オート クロップは不要。</translation>
+</phrase>
+
+<phrase>
+<original>Image is already cropped intelligently.  Autocrop abandoned.  (No changes were made to the image.)</original>
+<translation>画像はすでに見事にトリミングされています。  自動トリミングは行いません。  (画像に変更は加えられていません)</translation>
+</phrase>
+
+<phrase>
+<original>Cropping image</original>
+<translation>画像のトリミング</translation>
+</phrase>
+
+<phrase>
+<original>No active selection found.  Crop abandoned.</original>
+<translation>アクティブな選択範囲がありません。 切り抜きは行いません。</translation>
+</phrase>
+
+<phrase>
+<original>Flipping image</original>
+<translation>画像の反転</translation>
+</phrase>
+
+<phrase>
+<original>Mirroring image</original>
+<translation>画像のミラーリング</translation>
+</phrase>
+
+<phrase>
+<original>Rotating image</original>
+<translation>画像の回転</translation>
+</phrase>
+
+<phrase>
+<original>Fitting image canvas around layer</original>
+<translation>画像キャンバスをレイヤーに合わせる</translation>
+</phrase>
+
+<phrase>
+<original>Image is fully transparent.  Trim abandoned.</original>
+<translation>画像は完全に透明です。  トリムは行いません。</translation>
+</phrase>
+
+<phrase>
+<original>Image is already trimmed.  (No changes were made to the image.)</original>
+<translation>画像はすでにトリミングされています。  (画像に変更は加えられていません)</translation>
+</phrase>
+
+<phrase>
+<original>Trimming image</original>
+<translation>画像のトリミング</translation>
+</phrase>
+
+<!-- Filters_Transform.bas contains 29 phrases. 17 were duplicates of existing phrases, so only 12 new phrases were written to file. -->
+
+<phrase>
+<original>Loading page %1 of %2</original>
+<translation>ページ %1 / %2 をロードしています</translation>
+</phrase>
+
+<phrase>
+<original>Saving</original>
+<translation>保存</translation>
+</phrase>
+
+<phrase>
+<original>Save complete.</original>
+<translation>保存しました</translation>
+</phrase>
+
+<!-- GDIPlus.bas contains 3 phrases.  All 3 were unique, so 3 new phrases were written to file. -->
+
+<phrase>
+<original>Stretching histogram</original>
+<translation>ヒストグラムを伸張</translation>
+</phrase>
+
+<!-- Histograms.bas contains 2 phrases.  One was a duplicate of an existing phrase, so only 1 new phrases were written to file. -->
+
+<phrase>
+<original>Enter</original>
+<translation>Enter</translation>
+</phrase>
+
+<phrase>
+<original>Page Up</original>
+<translation>Page Up</translation>
+</phrase>
+
+<phrase>
+<original>Page Down</original>
+<translation>Page Down</translation>
+</phrase>
+
+<phrase>
+<original>Ctrl</original>
+<translation>Ctrl</translation>
+</phrase>
+
+<phrase>
+<original>Alt</original>
+<translation>Alt</translation>
+</phrase>
+
+<phrase>
+<original>Shift</original>
+<translation>Shift</translation>
+</phrase>
+
+<!-- Hotkeys.bas contains 12 phrases. 6 were duplicates of existing phrases, so only 6 new phrases were written to file. -->
+
+<phrase>
+<original>Saving %1 file</original>
+<translation>%1 のファイルを保存</translation>
+</phrase>
+
+<phrase>
+<original>%1 save failed. Please report this error using Help -> Submit Bug Report.</original>
+<translation>%1 の保存に失敗しました。 [ヘルプ] -> [バグ レポートまたはフィードバックの提出] を使用してこのエラーを報告してください。</translation>
+</phrase>
+
+<phrase>
+<original>The FreeImage interface plug-in (FreeImage.dll) was marked as missing or disabled upon program initialization.
+
+To enable support for this image format, please copy the FreeImage.dll file (downloadable from http://freeimage.sourceforge.net/download.html) into the plug-in directory and reload the program.</original>
+<translation>Freeimageインターフェイスプラグイン (FreeImage.dll) が、プログラムの初期化時に見つからない、または無効とマークされました。
+
+この画像形式のサポートを有効にするには、FreeImage.dll ファイル (http://freeimage.sourceforge.net/download.html からダウンロード可能) をプラグイン ディレクトリにコピーし、プログラムを再読み込みしてください。</translation>
+</phrase>
+
+<phrase>
+<original>Save cannot be completed without FreeImage library.</original>
+<translation>FreeImage ライブラリがないと保存が完了しません。</translation>
+</phrase>
+
+<!-- ImageExporter.bas contains 23 phrases. 19 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>All Compatible Images</original>
+<translation>すべての対応画像</translation>
+</phrase>
+
+<phrase>
+<original>All files</original>
+<translation>すべてのファイル</translation>
+</phrase>
+
+<!-- ImageFormats.bas contains 4 phrases. 2 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>An error has occurred (#%1 - %2).  PDI load abandoned.</original>
+<translation>エラーが発生しました (#%1 - %2)。  PDI ロードを中断しました。</translation>
+</phrase>
+
+<!-- ImageLoader.bas contains 2 phrases.  One was a duplicate of an existing phrase, so only 1 new phrases were written to file. -->
+
+<phrase>
+<original>Repeat</original>
+<translation>繰り返し</translation>
+</phrase>
+
+<phrase>
+<original>Fade: %1</original>
+<translation>フェード: %1</translation>
+</phrase>
+
+<phrase>
+<original>Repeat: %1</original>
+<translation>繰り返し: %1</translation>
+</phrase>
+
+<phrase>
+<original>Undo last action</original>
+<translation>最後の操作を取り消す</translation>
+</phrase>
+
+<phrase>
+<original>Redo previous action</original>
+<translation>前の操作をやり直す</translation>
+</phrase>
+
+<phrase>
+<original>Recording</original>
+<translation>記録中</translation>
+</phrase>
+
+<phrase>
+<original>clamp</original>
+<translation>固定</translation>
+</phrase>
+
+<phrase>
+<original>reflect</original>
+<translation>反射</translation>
+</phrase>
+
+<phrase>
+<original>wrap</original>
+<translation>反復</translation>
+</phrase>
+
+<phrase>
+<original>erase</original>
+<translation>消去</translation>
+</phrase>
+
+<phrase>
+<original>ignore</original>
+<translation>無視</translation>
+</phrase>
+
+<phrase>
+<original>square</original>
+<translation>正方形</translation>
+</phrase>
+
+<phrase>
+<original>diamond</original>
+<translation>ひし形</translation>
+</phrase>
+
+<phrase>
+<original>Normal</original>
+<translation>通常</translation>
+</phrase>
+
+<phrase>
+<original>Darken</original>
+<translation>比較 (暗)</translation>
+</phrase>
+
+<phrase>
+<original>Multiply</original>
+<translation>乗算</translation>
+</phrase>
+
+<phrase>
+<original>Color burn</original>
+<translation>焼き込みカラー</translation>
+</phrase>
+
+<phrase>
+<original>Linear burn</original>
+<translation>焼き込み (リニア)</translation>
+</phrase>
+
+<phrase>
+<original>Lighten</original>
+<translation>比較 (明)</translation>
+</phrase>
+
+<phrase>
+<original>Screen</original>
+<translation>スクリーン</translation>
+</phrase>
+
+<phrase>
+<original>Color dodge</original>
+<translation>覆い焼きカラー</translation>
+</phrase>
+
+<phrase>
+<original>Linear dodge</original>
+<translation>覆い焼き (リニア)</translation>
+</phrase>
+
+<phrase>
+<original>Overlay</original>
+<translation>オーバーレイ</translation>
+</phrase>
+
+<phrase>
+<original>Soft light</original>
+<translation>ソフトライト</translation>
+</phrase>
+
+<phrase>
+<original>Hard light</original>
+<translation>ハードライト</translation>
+</phrase>
+
+<phrase>
+<original>Vivid light</original>
+<translation>ビビッドライト</translation>
+</phrase>
+
+<phrase>
+<original>Linear light</original>
+<translation>リニアライト</translation>
+</phrase>
+
+<phrase>
+<original>Pin light</original>
+<translation>ピンライト</translation>
+</phrase>
+
+<phrase>
+<original>Hard mix</original>
+<translation>ハードミックス</translation>
+</phrase>
+
+<phrase>
+<original>Difference</original>
+<translation>差の絶対値</translation>
+</phrase>
+
+<phrase>
+<original>Exclusion</original>
+<translation>除外</translation>
+</phrase>
+
+<phrase>
+<original>Subtract</original>
+<translation>減算</translation>
+</phrase>
+
+<phrase>
+<original>Divide</original>
+<translation>除算</translation>
+</phrase>
+
+<phrase>
+<original>Hue</original>
+<translation>色相</translation>
+</phrase>
+
+<phrase>
+<original>Saturation</original>
+<translation>彩度</translation>
+</phrase>
+
+<phrase>
+<original>Color</original>
+<translation>カラー</translation>
+</phrase>
+
+<phrase>
+<original>Luminosity</original>
+<translation>輝度</translation>
+</phrase>
+
+<phrase>
+<original>Grain extract</original>
+<translation>微粒取り出し</translation>
+</phrase>
+
+<phrase>
+<original>Grain merge</original>
+<translation>微粒結合</translation>
+</phrase>
+
+<phrase>
+<original>Erase</original>
+<translation>消去</translation>
+</phrase>
+
+<phrase>
+<original>Inherit</original>
+<translation>継承</translation>
+</phrase>
+
+<phrase>
+<original>Locked</original>
+<translation>ロック</translation>
+</phrase>
+
+<phrase>
+<original>Perceptual</original>
+<translation>知覚的</translation>
+</phrase>
+
+<phrase>
+<original>Relative colorimetric</original>
+<translation>相対比色</translation>
+</phrase>
+
+<phrase>
+<original>Absolute colorimetric</original>
+<translation>絶対比色</translation>
+</phrase>
+
+<phrase>
+<original>color</original>
+<translation>色</translation>
+</phrase>
+
+<phrase>
+<original>color and opacity</original>
+<translation>色と不透明度</translation>
+</phrase>
+
+<phrase>
+<original>luminance</original>
+<translation>輝度</translation>
+</phrase>
+
+<phrase>
+<original>red only</original>
+<translation>赤のみ</translation>
+</phrase>
+
+<phrase>
+<original>green only</original>
+<translation>緑のみ</translation>
+</phrase>
+
+<phrase>
+<original>blue only</original>
+<translation>青のみ</translation>
+</phrase>
+
+<phrase>
+<original>alpha only</original>
+<translation>アルファのみ</translation>
+</phrase>
+
+<phrase>
+<original>Are you sure you want to cancel %1?</original>
+<translation>本当に%1をキャンセルしますか?</translation>
+</phrase>
+
+<phrase>
+<original>Cancel action</original>
+<translation>キャンセル</translation>
+</phrase>
+
+<phrase>
+<original>preview not available</original>
+<translation>プレビュー不可</translation>
+</phrase>
+
+<!-- Interface.bas contains 83 phrases. 28 were duplicates of existing phrases, so only 55 new phrases were written to file. -->
+
+<phrase>
+<original>Blank layer</original>
+<translation>空のレイヤー</translation>
+</phrase>
+
+<phrase>
+<original>Group start</original>
+<translation>グループスタート</translation>
+</phrase>
+
+<phrase>
+<original>Group end</original>
+<translation>グループ終了</translation>
+</phrase>
+
+<phrase>
+<original>Basic text layer</original>
+<translation>基本テキスト レイヤー</translation>
+</phrase>
+
+<phrase>
+<original>Advanced text layer</original>
+<translation>高度なテキスト レイヤー</translation>
+</phrase>
+
+<phrase>
+<original>Visible</original>
+<translation>可視</translation>
+</phrase>
+
+<phrase>
+<original>New layer from selection</original>
+<translation>選択範囲から新しいレイヤーを作成</translation>
+</phrase>
+
+<phrase>
+<original>Layer updated successfully.</original>
+<translation>レイヤーは正常に更新されました。</translation>
+</phrase>
+
+<phrase>
+<original>New layer added successfully.</original>
+<translation>新しいレイヤーが正常に追加されました。</translation>
+</phrase>
+
+<phrase>
+<original>Copying layer</original>
+<translation>レイヤーのコピー</translation>
+</phrase>
+
+<phrase>
+<original>Conversion complete.</original>
+<translation>コンバージョンを完了しました。</translation>
+</phrase>
+
+<phrase>
+<original>Adding image</original>
+<translation>画像の追加</translation>
+</phrase>
+
+<phrase>
+<original>Merged layers</original>
+<translation>マージされたレイヤー</translation>
+</phrase>
+
+<phrase>
+<original>This action will convert text and vector layers to image (raster) layers, meaning you can no longer modify layer-specific settings like text, font, color or shape.</original>
+<translation>このアクションは、テキストとベクター レイヤーをイメージ (ラスター)レイヤーに変換します。つまり、テキスト、フォント、カラー、シェイプなどのレイヤー固有の設定を変更できなくなります。</translation>
+</phrase>
+
+<phrase>
+<original>Are you sure you want to continue?</original>
+<translation>本当に続けるのか?</translation>
+</phrase>
+
+<phrase>
+<original>Yes.  Convert text and vector layers to image (raster) layers.</original>
+<translation>はい。  テキスト レイヤーとベクター レイヤーをイメージ (ラスター) レイヤーに変換します。</translation>
+</phrase>
+
+<phrase>
+<original>No.  Leave text and vector layers as they are.</original>
+<translation>いいえ、テキストとベクター レイヤーはそのままにしておきます。</translation>
+</phrase>
+
+<phrase>
+<original>This text layer will be changed to an image (raster) layer, meaning you can no longer modify its text or font settings.</original>
+<translation>このテキスト レイヤーは画像 (ラスター) レイヤーに変更され、テキストやフォントの設定を変更できなくなります。</translation>
+</phrase>
+
+<phrase>
+<original>Yes.  Please convert this text layer.</original>
+<translation>はい。  このテキスト レイヤーを変換してください。</translation>
+</phrase>
+
+<phrase>
+<original>No.  Leave this text layer as it is.</original>
+<translation>いいえ、このテキスト レイヤーはそのままにしておきます。</translation>
+</phrase>
+
+<phrase>
+<original>In the future, automatically rasterize without prompting me</original>
+<translation>将来的には、プロンプトを出さずに自動的にラスタライズされます</translation>
+</phrase>
+
+<phrase>
+<original>Paint layer</original>
+<translation>ペイント レイヤー</translation>
+</phrase>
+
+<phrase>
+<original>Frame %1</original>
+<translation>フレーム %1</translation>
+</phrase>
+
+<phrase>
+<original>Page %1</original>
+<translation>ページ %1</translation>
+</phrase>
+
+<!-- Layers.bas contains 58 phrases. 34 were duplicates of existing phrases, so only 24 new phrases were written to file. -->
+
+<phrase>
+<original>Loading image</original>
+<translation>画像を読み込む</translation>
+</phrase>
+
+<phrase>
+<original>Warning - file not found: %1</original>
+<translation>警告 - ファイルが見つかりません: %1</translation>
+</phrase>
+
+<phrase>
+<original>Unfortunately, the image '%1' could not be found.
+
+If this image was originally located on removable media (DVD, USB drive, etc), please re-insert or re-attach the media and try again.</original>
+<translation>残念ながら、画像 '%1' が見つかりません。
+
+この画像が元々リムーバブル メディア (DVD、USBドライブなど)にあった場合は、メディアを再挿入または再装着して再試行してください。</translation>
+</phrase>
+
+<phrase>
+<original>File not found</original>
+<translation>ファイルが見つかりません</translation>
+</phrase>
+
+<phrase>
+<original>Warning - file locked: %1</original>
+<translation>警告 - ファイルがロックされています: %1</translation>
+</phrase>
+
+<phrase>
+<original>Unfortunately, the file '%1' is currently locked by another program on this PC.
+
+Please close this file in any other running programs, then try again.</original>
+<translation>残念ながら、ファイル '%1' は現在この PC 上の別のプログラムによってロックされています。
+
+実行中の他のプログラムでこのファイルを閉じてから、再試行してください。</translation>
+</phrase>
+
+<phrase>
+<original>File locked</original>
+<translation>ファイルがロックされています</translation>
+</phrase>
+
+<phrase>
+<original>Image loaded successfully.</original>
+<translation>画像は正常に読み込まれました。</translation>
+</phrase>
+
+<phrase>
+<original>Failed to load %1</original>
+<translation>%1 をロードできませんでした</translation>
+</phrase>
+
+<phrase>
+<original>Unfortunately, PhotoDemon was unable to load the following image:
+
+%1
+
+Please use another program to save this image in a generic format (such as JPEG or PNG) before loading it.  Thanks!</original>
+<translation>残念ながら、PhotoDemon は以下の画像を読み込むことができませんでした: 
+
+%1
+
+ロードする前に、他のプログラムを使用して、この画像を一般的なフォーマット (JPEG または PNG など) で保存してください。  ありがとう!</translation>
+</phrase>
+
+<phrase>
+<original>Image import failed</original>
+<translation>画像のインポートに失敗しました</translation>
+</phrase>
+
+<phrase>
+<original>Layer import canceled.</original>
+<translation>レイヤーのインポートがキャンセルされました。</translation>
+</phrase>
+
+<phrase>
+<original>%1 of %2 images loaded successfully</original>
+<translation>%2 個中 %1 個の画像が正常にロードされました</translation>
+</phrase>
+
+<phrase>
+<original>Unfortunately, PhotoDemon was unable to load the following image(s):
+
+%1
+Please verify that these image(s) exist, and that they use a supported image format (like JPEG or PNG).  Thanks!</original>
+<translation>残念ながら、PhotoDemon は以下の画像をロードできませんでした: 
+
+%1
+これらの画像が存在し、サポートされている画像フォーマット (JPEG または PNG など) を使用していることを確認してください。  ありがとう!</translation>
+</phrase>
+
+<phrase>
+<original>Some images were not loaded</original>
+<translation>一部の画像が読み込まれませんでした</translation>
+</phrase>
+
+<phrase>
+<original>Duplicating current image</original>
+<translation>現在の画像を複製</translation>
+</phrase>
+
+<phrase>
+<original>Image duplication complete.</original>
+<translation>画像の複製が完了しました。</translation>
+</phrase>
+
+<!-- Loading.bas contains 28 phrases. 11 were duplicates of existing phrases, so only 17 new phrases were written to file. -->
+
+<phrase>
+<original>This macro does not contain any recordable actions.  Are you sure you want to stop recording?
+
+(Press No to continue recording.)</original>
+<translation>このマクロには記録可能なアクションは含まれていません。  本当に記録を停止しますか?
+
+(記録を続けるには「いいえ」を押してください)</translation>
+</phrase>
+
+<phrase>
+<original>Warning</original>
+<translation>警告</translation>
+</phrase>
+
+<phrase>
+<original>Macro canceled.</original>
+<translation>マクロはキャンセルされました。</translation>
+</phrase>
+
+<phrase>
+<original>Macro saved successfully.</original>
+<translation>マクロは正常に保存されました。</translation>
+</phrase>
+
+<phrase>
+<original>If you do not save this macro, all actions recorded during this session will be permanently lost.  Are you sure you want to cancel?
+
+(Press No to return to the Save Macro screen.  Note that you can always delete this macro later if you decide you don't want it.)</original>
+<translation>このマクロを保存しないと、このセッション中に記録されたすべてのアクションが永久に失われます。  本当にキャンセルしますか?
+
+(いいえ を押すとるマクロの保存の画面に戻ります。  なお、このマクロは不要と判断した場合は、あとでいつでも削除できます)</translation>
+</phrase>
+
+<phrase>
+<original>Warning: last chance to save macro</original>
+<translation>警告: マクロを保存する最後のチャンス</translation>
+</phrase>
+
+<phrase>
+<original>Macro</original>
+<translation>マクロ</translation>
+</phrase>
+
+<phrase>
+<original>Save macro</original>
+<translation>マクロを保存</translation>
+</phrase>
+
+<phrase>
+<original>Macro recording started.</original>
+<translation>マクロの記録を開始しました。</translation>
+</phrase>
+
+<phrase>
+<original>Macro recording stopped.</original>
+<translation>マクロの記録を停止しました。</translation>
+</phrase>
+
+<phrase>
+<original>Open macro</original>
+<translation>マクロを開く</translation>
+</phrase>
+
+<phrase>
+<original>Loading macro</original>
+<translation>マクロを読み込んでいます</translation>
+</phrase>
+
+<phrase>
+<original>Macro complete!</original>
+<translation>マクロを完了しました!</translation>
+</phrase>
+
+<phrase>
+<original>Incompatible macro found.  Macro canceled.</original>
+<translation>互換性のないマクロが見つかりました。  マクロはキャンセルされました。</translation>
+</phrase>
+
+<phrase>
+<original>Playing macro</original>
+<translation>マクロを再生</translation>
+</phrase>
+
+<!-- BatchProcessor.bas contains 26 phrases. 11 were duplicates of existing phrases, so only 15 new phrases were written to file. -->
+
+<phrase>
+<original>empty</original>
+<translation>なし</translation>
+</phrase>
+
+<phrase>
+<original>Clear recent macro list</original>
+<translation>最近使ったマクロのリストを消去</translation>
+</phrase>
+
+<!-- Menus.bas contains 12 phrases. 10 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>All supported palettes</original>
+<translation>すべてのサポートパレット</translation>
+</phrase>
+
+<phrase>
+<original>Adobe Color Swatch</original>
+<translation>アドビ カラー スウォッチ</translation>
+</phrase>
+
+<phrase>
+<original>Adobe Color Table</original>
+<translation>アドビ カラー テーブル</translation>
+</phrase>
+
+<phrase>
+<original>Adobe Swatch Exchange</original>
+<translation>アドビ スウォッチ エクスチェンジ</translation>
+</phrase>
+
+<phrase>
+<original>GIMP Palette</original>
+<translation>GIMP パレット</translation>
+</phrase>
+
+<phrase>
+<original>Paint.NET Palette</original>
+<translation>Paint.NET パレット</translation>
+</phrase>
+
+<phrase>
+<original>PaintShop Pro Palette</original>
+<translation>PaintShop Pro パレット</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon Palette</original>
+<translation>PhotoDemon パレット</translation>
+</phrase>
+
+<phrase>
+<original>Select a palette</original>
+<translation>パレットを選択</translation>
+</phrase>
+
+<phrase>
+<original>New palette</original>
+<translation>新しいパレット</translation>
+</phrase>
+
+<phrase>
+<original>Exporting palette</original>
+<translation>パレットのエクスポート</translation>
+</phrase>
+
+<phrase>
+<original>None</original>
+<translation>なし</translation>
+</phrase>
+
+<phrase>
+<original>Ordered (Bayer 4x4)</original>
+<translation>オーダー (バイエル4x4)</translation>
+</phrase>
+
+<phrase>
+<original>Ordered (Bayer 8x8)</original>
+<translation>オーダー (バイエル8x8)</translation>
+</phrase>
+
+<phrase>
+<original>Single neighbor</original>
+<translation>シングル ネイバー</translation>
+</phrase>
+
+<phrase>
+<original>Jarvis, Judice, and Ninke</original>
+<translation>ジャービス、ジュディス、ニンケ</translation>
+</phrase>
+
+<phrase>
+<original>Two-Row Sierra</original>
+<translation>2列シエラ</translation>
+</phrase>
+
+<phrase>
+<original>Sierra Lite</original>
+<translation>シエラライト</translation>
+</phrase>
+
+<phrase>
+<original>Atkinson / Classic Macintosh</original>
+<translation>アトキンソン / クラシック・マッキントッシュ</translation>
+</phrase>
+
+<!-- Palettes.bas contains 48 phrases. 29 were duplicates of existing phrases, so only 19 new phrases were written to file. -->
+
+<phrase>
+<original>Applying plugin</original>
+<translation>プラグインの適用</translation>
+</phrase>
+
+<!-- Plugin_8bf.bas contains 1 phrase.  The phrase was unique, so 1 new phrase was written to file. -->
+
+<phrase>
+<original>AVIF is a modern image format developed by the Alliance for Open Media.  PhotoDemon does not natively support AVIF images, but it can download a free, open-source plugin that permanently enables AVIF support.</original>
+<translation>AVIF は、Alliance for Open Mediaによって開発された最新の画像フォーマットです。  PhotoDemon は、ネイティブで AVIF 画像をサポートしていませんが、AVIF サポートを永続的に有効にする無料のオープン ソース プラグインをダウンロードできます。</translation>
+</phrase>
+
+<phrase>
+<original>The Alliance for Open Media provides free, open-source 64-bit AVIF encoder and decoder libraries.  These libraries are roughly ~%1 mb each (~%2 mb total).  Once downloaded, they will allow PhotoDemon to import and export AVIF files on any 64-bit system.</original>
+<translation>Alliance for Open Media は、フリーでオープンソースの64ビットAVIFエンコーダーとデコーダー ライブラリを提供しています。  これらのライブラリは、それぞれ約 ~%1 mb (合計 ~%2 mb) です。  ダウンロードすると、PhotoDemon が 64 ビットシステム上で AVIF ファイルをインポートおよびエクスポートできるようになります。</translation>
+</phrase>
+
+<phrase>
+<original>Would you like PhotoDemon to download these libraries to your PhotoDemon plugin folder?</original>
+<translation>PhotoDemon がこれらのライブラリを PhotoDemon プラグイン フォルダにダウンロードしますか?</translation>
+</phrase>
+
+<phrase>
+<original>Download required</original>
+<translation>ダウンロードが必要</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon will not download the AVIF libraries at this time.</original>
+<translation>PhotoDemon は、現時点では AVIF ライブラリをダウンロードしません。</translation>
+</phrase>
+
+<phrase>
+<original>To manually enable AVIF support, you can download the latest copies of the free "%1" and "%2" programs and place them into your PhotoDemon plugin folder</original>
+<translation>手動で AVIF サポートを有効にするには、無料の「%1」および「%2」プログラムの最新コピーをダウンロードし、PhotoDemon プラグイン フォルダに配置します。</translation>
+</phrase>
+
+<phrase>
+<original>These free libraries are always available at the Alliance for Open Media libavif release page</original>
+<translation>これらの無料ライブラリは、Alliance for Open Media の libavif リリースページからいつでも入手可能です。</translation>
+</phrase>
+
+<phrase>
+<original>Download canceled</original>
+<translation>ダウンロードをキャンセルしました</translation>
+</phrase>
+
+<phrase>
+<original>You have placed PhotoDemon in a restricted system folder.  Because PhotoDemon does not have administrator access, it cannot download files for you.  Please move PhotoDemon to an unrestricted folder and try again.</original>
+<translation>制限されたシステムフォルダに PhotoDemon を配置しました。  PhotoDemon は管理者権限を持っていないため、ファイルをダウンロードすることができません。  PhotoDemon を制限のないフォルダに移動し、再度お試しください。</translation>
+</phrase>
+
+<!-- Plugin_AVIF.bas contains 16 phrases. 7 were duplicates of existing phrases, so only 9 new phrases were written to file. -->
+
+<phrase>
+<original>Scanner successfully enabled</original>
+<translation>スキャナは正常に有効化されました</translation>
+</phrase>
+
+<phrase>
+<original>The selected scanner or digital camera isn't responding.
+
+Please make sure the device is turned on and ready for use.</original>
+<translation>選択したスキャナまたはデジタルカメラが応答しません。
+
+デバイスの電源が入っており、使用できる状態であることを確認してください。</translation>
+</phrase>
+
+<phrase>
+<original>Scanner error</original>
+<translation>スキャナーエラー</translation>
+</phrase>
+
+<phrase>
+<original>The scanner/digital camera interface plug-in (EZTW32.dll) was marked as missing upon program initialization.
+
+To enable scanner support, please copy the EZTW32.dll file (available for download from http://eztwain.com/ezt1_download.htm) into the plug-in directory and reload the program.</original>
+<translation>プログラムの初期化時に、スキャナー/デジタルカメラインターフェースプラグイン (EZTW32.Dll) が見つからないとマークされました。
+
+スキャナサポートを有効にするには、EZTW32.Dll ファイル (http://eztwain.com/ezt1_download.htm からダウンロード可能)をプラグインディレクトリにコピーし、プログラムを再読み込みしてください。</translation>
+</phrase>
+
+<phrase>
+<original>Acquiring image</original>
+<translation>画像の取得</translation>
+</phrase>
+
+<phrase>
+<original>Scanned Image</original>
+<translation>スキャン画像</translation>
+</phrase>
+
+<phrase>
+<original>Image acquired successfully</original>
+<translation>画像を正常に取得しました</translation>
+</phrase>
+
+<phrase>
+<original>Unknown error occurred.  Please make sure your scanner is turned on and ready for use.</original>
+<translation>不明なエラーが発生しました。  スキャナの電源が入っており、使用可能な状態であることを確認してください。</translation>
+</phrase>
+
+<phrase>
+<original>Scan successful, but temporary file save failed.  Is it possible that your hard drive is full (or almost full)?</original>
+<translation>スキャンは成功しましたが、一時ファイルの保存に失敗しました。  ハードディスクが一杯 (またはほぼ一杯)になっている可能性はありませんか?</translation>
+</phrase>
+
+<phrase>
+<original>Unable to acquire DIB lock.  Please make sure no other programs are accessing the scanner.  If the problem persists, reboot and try again.</original>
+<translation>DIB ロックを取得できません。  他のプログラムがスキャナにアクセスしていないことを確認してください。  問題が解決しない場合は、再起動して再度お試しください。</translation>
+</phrase>
+
+<phrase>
+<original>Temporary file access error.  This can be caused when running on a system with limited access rights.  Please enable admin rights and try again.</original>
+<translation>一時ファイルアクセスエラー。  これは、アクセス権が制限されたシステムで実行すると発生する可能性があります。  管理者権限を有効にして再度お試しください。</translation>
+</phrase>
+
+<phrase>
+<original>Scan canceled at the user's request.</original>
+<translation>ユーザーの要求によりスキャンをキャンセルしました。</translation>
+</phrase>
+
+<phrase>
+<original>Scan canceled</original>
+<translation>スキャンをキャンセルしました</translation>
+</phrase>
+
+<phrase>
+<original>The scanner returned an error code that wasn't specified in the EZTW32.dll documentation (Error #%1).  Please visit http://www.eztwain.com for more information.</original>
+<translation>スキャナは、EZTW32.dll ドキュメントで指定されていないエラーコードを返しました (エラー #%1)。  詳しくは http://www.eztwain.com をご参照ください。</translation>
+</phrase>
+
+<!-- Plugin_EZTwain.bas contains 32 phrases. 18 were duplicates of existing phrases, so only 14 new phrases were written to file. -->
+
+<phrase>
+<original>Import via FreeImage failed (Err # %1)</original>
+<translation>Freeimage でのインポートに失敗しました (エラー番号 %1)。</translation>
+</phrase>
+
+<phrase>
+<original>Applying tone-mapping</original>
+<translation>トーン マッピングの適用</translation>
+</phrase>
+
+<!-- Plugin_FreeImage.bas contains 4 phrases. 2 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>BSD license</original>
+<translation>BSD ライセンス</translation>
+</phrase>
+
+<phrase>
+<original>artistic license</original>
+<translation>artistic ライセンス</translation>
+</phrase>
+
+<phrase>
+<original>public domain</original>
+<translation>パブリック ドメイン</translation>
+</phrase>
+
+<phrase>
+<original>FreeImage public license</original>
+<translation>FreeImage パブリック ライセンス</translation>
+</phrase>
+
+<phrase>
+<original>MIT license</original>
+<translation>MIT ライセンス</translation>
+</phrase>
+
+<phrase>
+<original>Mozilla Public License 2.0</original>
+<translation>Mozilla パブリック ライセンス 2.0</translation>
+</phrase>
+
+<!-- Plugin_Management.bas contains 26 phrases. 20 were duplicates of existing phrases, so only 6 new phrases were written to file. -->
+
+<phrase>
+<original>Preparing image for printing</original>
+<translation>印刷用画像の準備</translation>
+</phrase>
+
+<phrase>
+<original>Image successfully sent to Windows Photo Printer.</original>
+<translation>Windows Photo Printer に画像が正常に送信されました。</translation>
+</phrase>
+
+<!-- Printing.bas contains 2 phrases.  Both phrases were unique, so 2 new phrases were written to file. -->
+
+<phrase>
+<original>Unknown processor request submitted: %1
+
+Please report this bug via the Help -> Submit Bug Report menu.</original>
+<translation>不明なプロセッサ要求が送信されました: %1
+
+Help -> Submit Bug Report メニューからこのバグを報告してください。</translation>
+</phrase>
+
+<phrase>
+<original>There is not enough memory available to continue this operation.  Please free up system memory (RAM) by shutting down unneeded programs - especially your web browser, if it is open - then try the action again.</original>
+<translation>この操作を続行するのに十分なメモリがありません。  不要なプログラム (特にウェブブラウザを開いている場合)をシャットダウンして、システムメモリ (RAM)を解放してから、操作をやり直してください。</translation>
+</phrase>
+
+<phrase>
+<original>Out of memory.  Function canceled.</original>
+<translation>メモリ不足。  機能がキャンセルされました。</translation>
+</phrase>
+
+<phrase>
+<original>The specified file could not be located.  If it was located on removable media, please re-insert the proper floppy disk, CD, or portable drive.  If the file is not located on portable media, make sure that:
+1) the file hasn't been deleted, and...
+2) the file location provided to PhotoDemon is correct.</original>
+<translation>指定されたファイルが見つかりません。  リムーバブルメディアにある場合は、適切なフロッピーディスク、CD、またはポータブルドライブを挿入し直してください。  ファイルがポータブルメディアにない場合、以下のことを確認してください: 
+1) ファイルが削除されていないこと。
+2) PhotoDemonに提供されたファイルの場所が正しい。</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon cannot locate additional information for this error.  That probably means this error is a bug, and it needs to be fixed!
+
+Would you like to submit a bug report?  (It takes less than one minute, and it helps everyone who uses the software.)</original>
+<translation>PhotoDemon は、このエラーの追加情報を見つけることができません。  それは、おそらくこのエラーがバグであり、修正される必要があることを意味します!
+
+バグ レポートを提出しますか?  (それは1分もかからず、ソフトウェアを使用するすべての人の助けになります)</translation>
+</phrase>
+
+<phrase>
+<original>Unknown error.</original>
+<translation>不明なエラー。</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon has experienced an error.  Details on the problem include:
+
+Error number %1
+Description: %2
+
+%3</original>
+<translation>PhotoDemonにエラーが発生しました。  問題の詳細は以下の通りです: 
+
+エラー番号 %1
+説明: %2
+
+%3</translation>
+</phrase>
+
+<phrase>
+<original>seconds</original>
+<translation>おかわり</translation>
+</phrase>
+
+<phrase>
+<original>name</original>
+<translation>名前</translation>
+</phrase>
+
+<phrase>
+<original>group</original>
+<translation>グループ</translation>
+</phrase>
+
+<phrase>
+<original>opacity</original>
+<translation>不透明度</translation>
+</phrase>
+
+<phrase>
+<original>blend mode</original>
+<translation>ブレンド モード</translation>
+</phrase>
+
+<phrase>
+<original>X offset</original>
+<translation>X オフセット</translation>
+</phrase>
+
+<phrase>
+<original>Y offset</original>
+<translation>Y オフセット</translation>
+</phrase>
+
+<phrase>
+<original>width</original>
+<translation>幅</translation>
+</phrase>
+
+<phrase>
+<original>height</original>
+<translation>高さ</translation>
+</phrase>
+
+<phrase>
+<original>angle</original>
+<translation>角度</translation>
+</phrase>
+
+<phrase>
+<original>visibility</original>
+<translation>視認性</translation>
+</phrase>
+
+<phrase>
+<original>non-destructive effect</original>
+<translation>非破壊効果</translation>
+</phrase>
+
+<phrase>
+<original>resize quality</original>
+<translation>リサイズの品質</translation>
+</phrase>
+
+<phrase>
+<original>horizontal shear</original>
+<translation>水平剪断</translation>
+</phrase>
+
+<phrase>
+<original>vertical shear</original>
+<translation>垂直せん断</translation>
+</phrase>
+
+<phrase>
+<original>alpha mode</original>
+<translation>アルファ モード</translation>
+</phrase>
+
+<phrase>
+<original>text</original>
+<translation>テキスト</translation>
+</phrase>
+
+<phrase>
+<original>font (color)</original>
+<translation>フォント(色)</translation>
+</phrase>
+
+<phrase>
+<original>font face</original>
+<translation>フォント フェイス</translation>
+</phrase>
+
+<phrase>
+<original>font size</original>
+<translation>フォント サイズ</translation>
+</phrase>
+
+<phrase>
+<original>font (size unit)</original>
+<translation>フォント (サイズの単位)</translation>
+</phrase>
+
+<phrase>
+<original>automatic fit</original>
+<translation>自動フィット</translation>
+</phrase>
+
+<phrase>
+<original>style (bold)</original>
+<translation>スタイル (太字)</translation>
+</phrase>
+
+<phrase>
+<original>style (italic)</original>
+<translation>スタイル (斜体)</translation>
+</phrase>
+
+<phrase>
+<original>style (underline)</original>
+<translation>スタイル (下線)</translation>
+</phrase>
+
+<phrase>
+<original>style (strikeout)</original>
+<translation>スタイル (打ち消し線)</translation>
+</phrase>
+
+<phrase>
+<original>horizontal alignment</original>
+<translation>水平揃え</translation>
+</phrase>
+
+<phrase>
+<original>vertical alignment</original>
+<translation>垂直揃え</translation>
+</phrase>
+
+<phrase>
+<original>antialiased</original>
+<translation>アンチエイリアス</translation>
+</phrase>
+
+<phrase>
+<original>clarity</original>
+<translation>明瞭さ</translation>
+</phrase>
+
+<phrase>
+<original>text type</original>
+<translation>テキスト タイプ</translation>
+</phrase>
+
+<phrase>
+<original>hinting</original>
+<translation>ヒンティング</translation>
+</phrase>
+
+<phrase>
+<original>word wrap</original>
+<translation>ワード ラップ</translation>
+</phrase>
+
+<phrase>
+<original>fill</original>
+<translation>塗りつぶし</translation>
+</phrase>
+
+<phrase>
+<original>fill style</original>
+<translation>塗りつぶし スタイル</translation>
+</phrase>
+
+<phrase>
+<original>outline</original>
+<translation>境界線</translation>
+</phrase>
+
+<phrase>
+<original>outline style</original>
+<translation>境界線のスタイル</translation>
+</phrase>
+
+<phrase>
+<original>background style</original>
+<translation>背景のスタイル</translation>
+</phrase>
+
+<phrase>
+<original>background border</original>
+<translation>背景のボーダー</translation>
+</phrase>
+
+<phrase>
+<original>background border style</original>
+<translation>背景のボーダー スタイル</translation>
+</phrase>
+
+<phrase>
+<original>line spacing</original>
+<translation>行間隔</translation>
+</phrase>
+
+<phrase>
+<original>margin</original>
+<translation>マージン</translation>
+</phrase>
+
+<phrase>
+<original>character remapping</original>
+<translation>文字のリマッピング</translation>
+</phrase>
+
+<phrase>
+<original>character spacing</original>
+<translation>文字間隔</translation>
+</phrase>
+
+<phrase>
+<original>character orientation</original>
+<translation>文字の向き</translation>
+</phrase>
+
+<phrase>
+<original>horizontal jitter</original>
+<translation>水平のゆらぎ</translation>
+</phrase>
+
+<phrase>
+<original>vertical jitter</original>
+<translation>垂直のゆらぎ</translation>
+</phrase>
+
+<phrase>
+<original>inflation</original>
+<translation>インフレ</translation>
+</phrase>
+
+<phrase>
+<original>mirroring</original>
+<translation>ミラーリング</translation>
+</phrase>
+
+<phrase>
+<original>Modify selection</original>
+<translation>選択の変更</translation>
+</phrase>
+
+<phrase>
+<original>Action canceled.</original>
+<translation>アクションがキャンセルされました。</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon has automatically opened the bug report webpage for you.  Please click the "New Issue" button, then select "Bug Report".  Answer the questions as best you can, and please include the following error number somewhere in your report: %1
+
+When finished, click the Submit New Issue button.  Thank you!</original>
+<translation>PhotoDemon は自動的にあなたのためにバグ レポートのウェブ ページを開きました。  "New Issue" ボタンをクリックし、"Bug Report "を選択してください。  可能な限り質問に答え、次のエラー番号をレポートのどこかに記載してください:  %1
+
+完了したら、新しい issue を提出するボタンをクリックしてください。  ありがとう!</translation>
+</phrase>
+
+<phrase>
+<original>Bug report instructions</original>
+<translation>バグの報告方法</translation>
+</phrase>
+
+<!-- Processor.bas contains 128 phrases. 68 were duplicates of existing phrases, so only 60 new phrases were written to file. -->
+
+<phrase>
+<original>automatic</original>
+<translation>オート</translation>
+</phrase>
+
+<phrase>
+<original>nearest-neighbor</original>
+<translation>ニアレスト ネイバー</translation>
+</phrase>
+
+<phrase>
+<original>bilinear</original>
+<translation>バイリニア</translation>
+</phrase>
+
+<phrase>
+<original>cosine</original>
+<translation>コサイン</translation>
+</phrase>
+
+<phrase>
+<original>bell</original>
+<translation>ベル</translation>
+</phrase>
+
+<phrase>
+<original>quadratic</original>
+<translation>二次</translation>
+</phrase>
+
+<phrase>
+<original>quadratic b-spline</original>
+<translation>二次 B スプライン</translation>
+</phrase>
+
+<phrase>
+<original>bicubic</original>
+<translation>バイキュービック</translation>
+</phrase>
+
+<phrase>
+<original>cubic convolution</original>
+<translation>三次畳み込み</translation>
+</phrase>
+
+<!-- Resampling.bas contains 18 phrases. 9 were duplicates of existing phrases, so only 9 new phrases were written to file. -->
+
+<phrase>
+<original>An error occurred when attempting to save this image.  The FreeImage plugin reported the following error details: 
+
+%1
+
+In the meantime, please try saving the image to an alternate format.  You can also let the PhotoDemon developers know about this via the Help > Submit Bug Report menu.</original>
+<translation>この画像を保存しようとするとエラーが発生しました。  FreeImage プラグインは以下のエラー詳細を報告しました: 
+
+%1
+
+とりあえず、画像を別のフォーマットに保存してみてください。  また、PhotoDemon の開発者に、[ヘルプ] > [バグ レポートまたはフィードバックの提出] メニューからこのことを知らせることができます。</translation>
+</phrase>
+
+<phrase>
+<original>Output format not recognized.  Save aborted.  Please use the Help -> Submit Bug Report menu item to report this incident.</original>
+<translation>出力形式が認識されません。  保存が中断されました。  [ヘルプ] -> [バグ レポートまたはフィードバックの提出] メニュー項目を使用して、この事象を報告してください。</translation>
+</phrase>
+
+<phrase>
+<original>Saving %1 image</original>
+<translation>%1 画像の保存</translation>
+</phrase>
+
+<phrase>
+<original>Saving file</original>
+<translation>ファイルの保存</translation>
+</phrase>
+
+<phrase>
+<original>This is a still image (only one frame of animation).</original>
+<translation>これは静止画です (アニメーションが 1 フレームのみ)。</translation>
+</phrase>
+
+<phrase>
+<original>You may proceed, but the image will be saved as a static image, not an animated one.</original>
+<translation>続行できますが、画像はアニメーションではなく静止画として保存されます。</translation>
+</phrase>
+
+<phrase>
+<original>Export animation</original>
+<translation>アニメーションをエクスポート</translation>
+</phrase>
+
+<!-- Saving.bas contains 41 phrases. 34 were duplicates of existing phrases, so only 7 new phrases were written to file. -->
+
+<phrase>
+<original>Capturing screen</original>
+<translation>画面のキャプチャ</translation>
+</phrase>
+
+<phrase>
+<original>Could not retrieve program window - the program appears to have been unloaded.</original>
+<translation>プログラムのウィンドウを取得できませんでした - プログラムがアンロードされたようです。</translation>
+</phrase>
+
+<phrase>
+<original>Screen capture complete.</original>
+<translation>スクリーンキャプチャを完了しました。</translation>
+</phrase>
+
+<phrase>
+<original>Screenshot options</original>
+<translation>スクリーンショットオプション</translation>
+</phrase>
+
+<!-- ScreenCapture.bas contains 7 phrases. 3 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>This action requires an active selection.  Please create a selection before continuing.</original>
+<translation>この操作にはアクティブな選択範囲が必要です。  続行する前に選択範囲作成してください。</translation>
+</phrase>
+
+<phrase>
+<original>Export selection as image</original>
+<translation>選択部分を画像としてエクスポート</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon selection</original>
+<translation>PhotoDemon 選択範囲</translation>
+</phrase>
+
+<phrase>
+<original>Load a previously saved selection</original>
+<translation>以前に保存した選択項目を読み込む</translation>
+</phrase>
+
+<phrase>
+<original>An error occurred while attempting to load %1.  Please verify that the file is a valid PhotoDemon selection file.</original>
+<translation>%1 をロードしようとしてエラーが発生しました。  ファイルが有効なPhotoDemon選択ファイルであることを確認してください。</translation>
+</phrase>
+
+<phrase>
+<original>Loading selection</original>
+<translation>選択範囲の読み込み</translation>
+</phrase>
+
+<phrase>
+<original>Selection loaded successfully</original>
+<translation>選択範囲を正常に読み込みました</translation>
+</phrase>
+
+<phrase>
+<original>Save the current selection</original>
+<translation>現在の選択範囲を保存</translation>
+</phrase>
+
+<phrase>
+<original>Selection saved.</original>
+<translation>選択範囲が保存されました。</translation>
+</phrase>
+
+<phrase>
+<original>Unknown error occurred.  Selection was not saved.  Please try again.</original>
+<translation>不明なエラーが発生しました。  選択範囲は保存されませんでした。  もう一度お試しください。</translation>
+</phrase>
+
+<!-- SelectionFiles.bas contains 25 phrases. 15 were duplicates of existing phrases, so only 10 new phrases were written to file. -->
+
+<phrase>
+<original>Selection inversion complete.</original>
+<translation>選択範囲を反転しました。</translation>
+</phrase>
+
+<phrase>
+<original>Feathering selection</original>
+<translation>選択範囲をぼかす</translation>
+</phrase>
+
+<phrase>
+<original>Feathering complete.</original>
+<translation>ぼかしを完了しました。</translation>
+</phrase>
+
+<phrase>
+<original>Sharpening selection</original>
+<translation>選択範囲のシャープネス</translation>
+</phrase>
+
+<phrase>
+<original>Growing selection</original>
+<translation>選択範囲の拡張</translation>
+</phrase>
+
+<phrase>
+<original>Selection resize complete.</original>
+<translation>選択範囲をリサイズしました。</translation>
+</phrase>
+
+<phrase>
+<original>Shrinking selection</original>
+<translation>選択範囲の縮小</translation>
+</phrase>
+
+<phrase>
+<original>Finding selection border</original>
+<translation>選択範囲の枠を見つける</translation>
+</phrase>
+
+<!-- SelectionFilters.bas contains 18 phrases. 10 were duplicates of existing phrases, so only 8 new phrases were written to file. -->
+
+<!-- Selections.bas contains 1 phrase.  One was a duplicate of an existing phrase, so only 0 new phrases were written to file. -->
+
+<phrase>
+<original>Create selection</original>
+<translation>選択範囲の作成</translation>
+</phrase>
+
+<phrase>
+<original>Release the mouse button to complete the lasso selection</original>
+<translation>マウスボタンを離すと、投げ縄の選択が完了します。</translation>
+</phrase>
+
+<phrase>
+<original>Move selection</original>
+<translation>移動選択</translation>
+</phrase>
+
+<phrase>
+<original>Resize selection</original>
+<translation>選択範囲のサイズ変更</translation>
+</phrase>
+
+<phrase>
+<original>Click on the first point to complete the polygon selection</original>
+<translation>最初の点をクリックして、ポリゴンの選択を完了します</translation>
+</phrase>
+
+<!-- SelectionUI.bas contains 26 phrases. 21 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<!-- Strings.bas contains 2 phrases.  All were duplicates of existing phrases, so no new phrases were written to file. -->
+
+<phrase>
+<original>%1 is not a valid entry.
+Please enter a value between %2 and %3.</original>
+<translation>%1 は有効なエントリではありません。
+%2 と %3 の間の値を入力してください。</translation>
+</phrase>
+
+<phrase>
+<original>Invalid entry</original>
+<translation>無効なエントリ</translation>
+</phrase>
+
+<phrase>
+<original>%1 is not a valid entry.
+Please enter a numeric value.</original>
+<translation>%1 は有効な入力ではありません。
+数値を入力してください。</translation>
+</phrase>
+
+<!-- TextSupport.bas contains 8 phrases. 5 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>Resize layer (on-canvas)</original>
+<translation>レイヤーのサイズ変更 (オンキャンバス)</translation>
+</phrase>
+
+<phrase>
+<original>Rotate layer (on-canvas)</original>
+<translation>レイヤーの回転 (オンキャンバス)</translation>
+</phrase>
+
+<phrase>
+<original>Move selected pixels</original>
+<translation>選択したピクセルを移動</translation>
+</phrase>
+
+<phrase>
+<original>Move layer</original>
+<translation>レイヤーの移動</translation>
+</phrase>
+
+<!-- Tools.bas contains 4 phrases.  All 4 were unique, so 4 new phrases were written to file. -->
+
+<phrase>
+<original>Ctrl+Click to set clone source</original>
+<translation>Ctrl+クリックでクローン元を設定</translation>
+</phrase>
+
+<phrase>
+<original>Clone stamp</original>
+<translation>クローン スタンプ</translation>
+</phrase>
+
+<!-- Clonestamp.bas contains 3 phrases.  One was a duplicate of an existing phrase, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>Fill tool</original>
+<translation>塗りつぶしツール</translation>
+</phrase>
+
+<!-- FillTool.bas contains 3 phrases. 2 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>Gradient tool</original>
+<translation>グラデーション ツール</translation>
+</phrase>
+
+<!-- GradientTool.bas contains 2 phrases.  One was a duplicate of an existing phrase, so only 1 new phrases were written to file. -->
+
+<!-- MeasureTool.bas contains 2 phrases.  All were duplicates of existing phrases, so no new phrases were written to file. -->
+
+<phrase>
+<original>Ctrl+click to move the active layer here</original>
+<translation>Ctrl+クリックでアクティブ レイヤーをここに移動する</translation>
+</phrase>
+
+<phrase>
+<original>Shift key: preserve layer aspect ratio</original>
+<translation>Shift キー: レイヤーの縦横比を保持</translation>
+</phrase>
+
+<phrase>
+<original>Target: selected pixels</original>
+<translation>対象: 選択されたピクセル</translation>
+</phrase>
+
+<phrase>
+<original>Target layer: %1</original>
+<translation>対象レイヤー: %1</translation>
+</phrase>
+
+<phrase>
+<original>(none)</original>
+<translation>(なし)</translation>
+</phrase>
+
+<!-- MoveTool.bas contains 12 phrases. 7 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<phrase>
+<original>Paint stroke</original>
+<translation>ストロークのびょぅ画</translation>
+</phrase>
+
+<!-- Paintbrush.bas contains 2 phrases.  One was a duplicate of an existing phrase, so only 1 new phrases were written to file. -->
+
+<phrase>
+<original>Pencil stroke</original>
+<translation>鉛筆のストローク</translation>
+</phrase>
+
+<!-- PencilTool.bas contains 2 phrases.  One was a duplicate of an existing phrase, so only 1 new phrases were written to file. -->
+
+<phrase>
+<original>(enter text here)</original>
+<translation>(ここにテキストを入力する)</translation>
+</phrase>
+
+<phrase>
+<original>New text layer</original>
+<translation>新しいテキスト レイヤー</translation>
+</phrase>
+
+<!-- TextTools.bas contains 5 phrases. 3 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>px</original>
+<translation>px</translation>
+</phrase>
+
+<phrase>
+<original>in</original>
+<translation>in</translation>
+</phrase>
+
+<phrase>
+<original>cm</original>
+<translation>cm</translation>
+</phrase>
+
+<phrase>
+<original>mm</original>
+<translation>mm</translation>
+</phrase>
+
+<phrase>
+<original>pt</original>
+<translation>pt</translation>
+</phrase>
+
+<phrase>
+<original>pc</original>
+<translation>pc</translation>
+</phrase>
+
+<phrase>
+<original>percent</original>
+<translation>パーセント</translation>
+</phrase>
+
+<phrase>
+<original>pixels</original>
+<translation>ピクセル</translation>
+</phrase>
+
+<phrase>
+<original>inches</original>
+<translation>インチ</translation>
+</phrase>
+
+<phrase>
+<original>centimeters</original>
+<translation>センチメートル</translation>
+</phrase>
+
+<phrase>
+<original>millimeters</original>
+<translation>ミリメートル</translation>
+</phrase>
+
+<phrase>
+<original>points</original>
+<translation>ポイント</translation>
+</phrase>
+
+<phrase>
+<original>picas</original>
+<translation>ピカ</translation>
+</phrase>
+
+<!-- Units.bas contains 26 phrases. 13 were duplicates of existing phrases, so only 13 new phrases were written to file. -->
+
+<phrase>
+<original>Update check postponed (a check has been performed recently)</original>
+<translation>更新チェックの延期 (チェックは最近行われました)</translation>
+</phrase>
+
+<phrase>
+<original>unknown</original>
+<translation>不明</translation>
+</phrase>
+
+<phrase>
+<original>Initializing software updater (this feature can be disabled from the Tools -> Options menu)</original>
+<translation>ソフトウェアのアップデータを初期化 (この機能は [ツール] -> [オプション] メニューで無効にできます)</translation>
+</phrase>
+
+<phrase>
+<original>%1.%2 Beta %3</original>
+<translation>%1.%2 ベータ %3</translation>
+</phrase>
+
+<phrase>
+<original>pre-alpha</original>
+<translation>プレアルファ</translation>
+</phrase>
+
+<phrase>
+<original>alpha</original>
+<translation>アルファ</translation>
+</phrase>
+
+<phrase>
+<original>beta</original>
+<translation>ベータ</translation>
+</phrase>
+
+<!-- UpdateEngine.bas contains 12 phrases. 5 were duplicates of existing phrases, so only 7 new phrases were written to file. -->
+
+<phrase>
+<original>Toggle between 1x and repeating previews</original>
+<translation>プレビューの等速と繰り返しを切り替え</translation>
+</phrase>
+
+<phrase>
+<original>Previously saved presets can be selected here.  You can save the current settings as a new preset by clicking the Save Preset button on the right.</original>
+<translation>以前に保存したプリセットはここで選択できます。 右のプリセット保存ボタンをクリックすると、現在の設定を新しいプリセットとして保存できます。</translation>
+</phrase>
+
+<phrase>
+<original>Randomly select new settings for this tool.  This is helpful for exploring how different settings affect the image.</original>
+<translation>このツールの新しい設定をランダムに選択します。 これは、異なる設定が画像にどのような影響を与えるかを調べるのに便利です。</translation>
+</phrase>
+
+<phrase>
+<original>Redo (fast-forward to a later state)</original>
+<translation>やり直し (後の状態に早送りする)</translation>
+</phrase>
+
+<phrase>
+<original>Reset all settings to their default values.</original>
+<translation>すべての設定を既定値に戻す。</translation>
+</phrase>
+
+<phrase>
+<original>Save the current settings as a new preset.</original>
+<translation>現在の設定を新しいプリセットとして保存します。</translation>
+</phrase>
+
+<phrase>
+<original>Undo (rewind to an earlier state)</original>
+<translation>元に戻す (以前の状態に巻き戻す)</translation>
+</phrase>
+
+<phrase>
+<original>Pin this panel open</original>
+<translation>このパネルをピンで留める</translation>
+</phrase>
+
+<phrase>
+<original>Toolbox panels close automatically, but you can pin one to keep it open.  (Pinned panels still close when switching tools or opening new panels.)</original>
+<translation>ツールボックスのパネルは自動的に閉じますが、ピン留めして開いておくことができます。  (ピン留めしたパネルは、ツールを切り替えたり新しいパネルを開いたりしても閉じます)</translation>
+</phrase>
+
+<phrase>
+<original>Generate a new random number seed.</original>
+<translation>新しい乱数シードを生成します。</translation>
+</phrase>
+
+<!-- UserControl_Support.bas contains 20 phrases. 10 were duplicates of existing phrases, so only 10 new phrases were written to file. -->
+
+<phrase>
+<original>This image does not contain any GPS metadata.</original>
+<translation>この画像にはGPSメタデータは含まれていません。</translation>
+</phrase>
+
+<phrase>
+<original>No GPS data found</original>
+<translation>GPSデータが見つからない</translation>
+</phrase>
+
+<phrase>
+<original>Attempting to connect to the Internet</original>
+<translation>インターネットへの接続を試みる</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon cannot reach the Internet.  Please double-check your connection and try again.</original>
+<translation>PhotoDemon がインターネットに接続できません。  接続を再確認し、再度お試しください。</translation>
+</phrase>
+
+<phrase>
+<original>Verifying URL (this may take a moment)</original>
+<translation>URL の確認 (少し時間がかかります)</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon could not reach the target URL (%1).  If the problem persists, try downloading the file manually using your Internet browser.</original>
+<translation>PhotoDemon は対象の URL (%1) に到達できませんでした。  問題が解決しない場合、インターネットブラウザを使用して手動でファイルをダウンロードしてください。</translation>
+</phrase>
+
+<phrase>
+<original>Downloading</original>
+<translation>ダウンロード</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon lost Internet access. Please double-check your connection.</original>
+<translation>PhotoDemon はインターネットアクセスを失いました。接続を再確認してください。</translation>
+</phrase>
+
+<phrase>
+<original>Downloading (%1 of %2 bytes)</original>
+<translation>ダウンロード中 (%1 / %2 バイト)</translation>
+</phrase>
+
+<phrase>
+<original>Download complete. Verifying file integrity</original>
+<translation>ダウンロード完了ファイルの整合性を確認</translation>
+</phrase>
+
+<phrase>
+<original>Download canceled.  (Remote server denied access.)</original>
+<translation>ダウンロードがキャンセルされました。  (リモートサーバーがアクセスを拒否しました。)</translation>
+</phrase>
+
+<phrase>
+<original>Unfortunately, %1 prevented PhotoDemon from directly downloading this file. (Direct downloads are sometimes mistaken as hotlinking by misconfigured servers.)
+
+You will need to manually download this file using your Internet browser.</original>
+<translation>残念ながら、%1は PhotoDemon がこのファイルを直接ダウンロードすることを妨げました。(直接ダウンロードは、時々、誤った設定のサーバによりホット リンクと間違われます)
+
+インターネットブラウザを使用して、このファイルを手動でダウンロードする必要があります。</translation>
+</phrase>
+
+<!-- Web.bas contains 17 phrases. 5 were duplicates of existing phrases, so only 12 new phrases were written to file. -->
+
+<phrase>
+<original>Fit width</original>
+<translation>幅にフィット</translation>
+</phrase>
+
+<phrase>
+<original>Fit height</original>
+<translation>高さにフィット</translation>
+</phrase>
+
+<phrase>
+<original>Fit image</original>
+<translation>画像にフィット</translation>
+</phrase>
+
+<!-- Zoom.bas contains 6 phrases. 3 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>Unnamed gradient</original>
+<translation>無題のグラデーション</translation>
+</phrase>
+
+<!-- pd2DGradient.cls contains 4 phrases. 3 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<!-- pdCBZ.cls contains 1 phrase.  One was a duplicate of an existing phrase, so only 0 new phrases were written to file. -->
+
+<phrase>
+<original>The clipboard is empty or it does not contain a valid picture format.  Please copy a valid image onto the clipboard and try again.</original>
+<translation>クリップボードが空か、有効な画像形式が含まれていません。 有効な画像をクリップボードにコピーして、もう一度やり直してください。</translation>
+</phrase>
+
+<phrase>
+<original>Clipboard Image</original>
+<translation>クリップボード画像</translation>
+</phrase>
+
+<phrase>
+<original>Clipboard data imported successfully</original>
+<translation>クリップボード データを正常にインポートしました</translation>
+</phrase>
+
+<phrase>
+<original>Image URL found.  Attempting to download</original>
+<translation>画像の URL が見つかりました。  ダウンロードを試みます</translation>
+</phrase>
+
+<phrase>
+<original>Image imported successfully</original>
+<translation>画像を正常にインポートしました</translation>
+</phrase>
+
+<phrase>
+<original>Image download failed.  Please copy a valid image URL and try again.</original>
+<translation>画像のダウンロードに失敗しました。  有効な画像 URL をコピーして再度お試しください。</translation>
+</phrase>
+
+<phrase>
+<original>Imported Image</original>
+<translation>画像をインポート</translation>
+</phrase>
+
+<!-- pdClipboardMain.cls contains 31 phrases. 24 were duplicates of existing phrases, so only 7 new phrases were written to file. -->
+
+<phrase>
+<original>Unknown adapter</original>
+<translation>不明なアダプター</translation>
+</phrase>
+
+<phrase>
+<original>Unknown display</original>
+<translation>不明なディスプレイ</translation>
+</phrase>
+
+<!-- pdDisplays.cls contains 6 phrases. 4 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>Please select a folder</original>
+<translation>フォルダを選択してください</translation>
+</phrase>
+
+<!-- pdFSO.cls contains 2 phrases.  One was a duplicate of an existing phrase, so only 1 new phrases were written to file. -->
+
+<phrase>
+<original>Optimizing animation frame %1 of %2</original>
+<translation>%2 個中の %1 個目のアニメーション フレームを最適化しています</translation>
+</phrase>
+
+<phrase>
+<original>Saving animation frame %1 of %2</original>
+<translation>%2 個中の %1 個目のアニメーション フレームを保存しています</translation>
+</phrase>
+
+<phrase>
+<original>Finalizing image</original>
+<translation>画像の仕上げをしています</translation>
+</phrase>
+
+<!-- pdGIF.cls contains 3 phrases.  All 3 were unique, so 3 new phrases were written to file. -->
+
+<phrase>
+<original>Repainting selected regions</original>
+<translation>選択領域の再塗装</translation>
+</phrase>
+
+<!-- pdInpaint.cls contains 1 phrase.  The phrase was unique, so 1 new phrase was written to file. -->
+
+<phrase>
+<original>New layer</original>
+<translation>新しいレイヤー</translation>
+</phrase>
+
+<!-- pdLayer.cls contains 4 phrases. 3 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>Building color lookup</original>
+<translation>ビルディング カラー ルックアップ</translation>
+</phrase>
+
+<phrase>
+<original>All supported LUTs</original>
+<translation>サポートされるすべてのLUT</translation>
+</phrase>
+
+<phrase>
+<original>Select a LUT file</original>
+<translation>LUTファイルを選択</translation>
+</phrase>
+
+<!-- pdLUT3D.cls contains 8 phrases. 5 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<!-- pdMakeTexture.cls contains 2 phrases.  All were duplicates of existing phrases, so no new phrases were written to file. -->
+
+<phrase>
+<original>Layer %1</original>
+<translation>レイヤー %1</translation>
+</phrase>
+
+<!-- pdMBM.cls contains 2 phrases.  One was a duplicate of an existing phrase, so only 1 new phrases were written to file. -->
+
+<phrase>
+<original>ExifTool plugin missing.  Metadata import abandoned.</original>
+<translation>ExifTool プラグインが見つかりません。  メタデータのインポートを中断しました。</translation>
+</phrase>
+
+<phrase>
+<original>Inferred</original>
+<translation>推定</translation>
+</phrase>
+
+<phrase>
+<original>Exif (thumbnail)</original>
+<translation>Exif (サムネイル)</translation>
+</phrase>
+
+<phrase>
+<original>Exif</original>
+<translation>Exif</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Apple)</original>
+<translation>XMP (Apple)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (ACD Systems)</original>
+<translation>XMP (ACD Systems)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Adobe Album)</original>
+<translation>XMP (Adobe アルバム)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Adobe)</original>
+<translation>XMP (Adobe)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Creative Commons)</original>
+<translation>XMP (クリエイティブ コモンズ)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Sony Ericcson)</original>
+<translation>XMP (ソニー・エリクソン)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Adobe After Effects)</original>
+<translation>XMP (Adobe After Effects)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Photoshop Camera Raw)</original>
+<translation>XMP (Photoshop Camera Raw)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Dublin Core)</original>
+<translation>XMP (Dublin Core)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Description Explorer)</original>
+<translation>XMP (Description Explorer)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (DICOM)</original>
+<translation>XMP (DICOM)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (DigiKam)</original>
+<translation>XMP (デジカム)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (EXIF)</original>
+<translation>XMP (EXIF)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (EXIF 2.3)</original>
+<translation>XMP (EXIF 2.3)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Microsoft Expression Media)</original>
+<translation>XMP (Microsoft Expression Media)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Extensis Portfolio)</original>
+<translation>XMP (Extensis Portfolio)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Fast Picture Viewer)</original>
+<translation>XMP (高速画像ビューア)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Getty Images)</original>
+<translation>XMP (Getty Images)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Google Photosphere)</original>
+<translation>XMP (Google Photosphere)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (IDimager)</original>
+<translation>XMP (IDimager)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (IPTC Core)</original>
+<translation>XMP (Iptcコア)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (IPTC Extension)</original>
+<translation>XMP (Iptc拡張)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Adobe Lightroom)</original>
+<translation>XMP (Adobe Lightroom)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (iView MediaPro)</original>
+<translation>XMP (iView MediaPro)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Microsoft Photo 1.0)</original>
+<translation>XMP (Microsoft Photo 1.0)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Microsoft Photo 1.2)</original>
+<translation>XMP (Microsoft Photo 1.2)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Microsoft Photo 1.1)</original>
+<translation>XMP (Microsoft Photo 1.1)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (MWG)</original>
+<translation>XMP (MWG)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Adobe PDF)</original>
+<translation>XMP (Adobe PDF)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Adobe PDF extended)</original>
+<translation>XMP (Adobe PDF 拡張)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (PhotoMechanic)</original>
+<translation>XMP (PhotoMechanic)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Adobe Photoshop)</original>
+<translation>XMP (Adobe Photoshop)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (PixelLive)</original>
+<translation>XMP (ピクセルライブ)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Plus License Data)</original>
+<translation>XMP (プラス・ライセンス・データ)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (PRISM for images)</original>
+<translation>XMP (画像用PRISM)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (PRISM)</original>
+<translation>XMP (プリズム)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (PRISM Rights)</original>
+<translation>XMP (Prismライツ)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (PRISM Recipe)</original>
+<translation>XMP (Prismレシピ)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (PRISM Usage Rights)</original>
+<translation>XMP (Prism利用権)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (RDF)</original>
+<translation>XMP (RDF)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Adobe SWF)</original>
+<translation>XMP (アドビswf)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (EXIF-TIFF)</original>
+<translation>Xmp (exif-tiff)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Toolkit)</original>
+<translation>XMP (ツールキット)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (General)</original>
+<translation>XMP (全般)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Basic Job)</original>
+<translation>XMP (ベーシック・ジョブ)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Dynamic Media)</original>
+<translation>XMP (ダイナミックメディア)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Media Management)</original>
+<translation>XMP (メディア管理)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Note)</original>
+<translation>XMP (注)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Picture Licensing)</original>
+<translation>XMP (ピクチャーライセンス)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Rights Management)</original>
+<translation>XMP (著作権管理)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Paged Text)</original>
+<translation>XMP (ページングされたテキスト)</translation>
+</phrase>
+
+<phrase>
+<original>XMP (Misc)</original>
+<translation>XMP (その他)</translation>
+</phrase>
+
+<phrase>
+<original>Removing metadata with potential privacy concerns</original>
+<translation>プライバシーに関わる可能性のあるメタデータの削除</translation>
+</phrase>
+
+<phrase>
+<original>Embedding metadata</original>
+<translation>メタデータの埋め込み</translation>
+</phrase>
+
+<!-- pdMetadata.cls contains 121 phrases. 63 were duplicates of existing phrases, so only 58 new phrases were written to file. -->
+
+<phrase>
+<original>Unfortunately, the number of images you selected exceeds what Windows allows for a single load operation.  Please try again with a smaller set of images.</original>
+<translation>残念ながら、選択された画像の数は、Windowsが1回のロード操作で許容する数を超えています。  より少ない画像セットで再試行してください。</translation>
+</phrase>
+
+<phrase>
+<original>Load canceled.</original>
+<translation>ロードはキャンセルされました。</translation>
+</phrase>
+
+<!-- pdOpenSaveDialog.cls contains 4 phrases. 2 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>palette exported by PhotoDemon %1</original>
+<translation>PhotoDemon %1 によってエクスポートされたパレット。</translation>
+</phrase>
+
+<!-- pdPalette.cls contains 4 phrases. 3 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>Analyzing animation frame %1 of %2</original>
+<translation>%2 個中の %1 個目のアニメーション フレームを解析しています。</translation>
+</phrase>
+
+<!-- pdPNG.cls contains 5 phrases. 4 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>%1 (Channel %2)</original>
+<translation>%1 (チャンネル %2)</translation>
+</phrase>
+
+<phrase>
+<original>Background</original>
+<translation>背景</translation>
+</phrase>
+
+<!-- pdPSD.cls contains 16 phrases. 14 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<!-- pdPSDLayer.cls contains 2 phrases.  All were duplicates of existing phrases, so no new phrases were written to file. -->
+
+<phrase>
+<original>Composite image</original>
+<translation>合成画像</translation>
+</phrase>
+
+<!-- pdPSP.cls contains 10 phrases. 9 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>Reconstructing image</original>
+<translation>画像の再構成</translation>
+</phrase>
+
+<phrase>
+<original>Image successfully restored.</original>
+<translation>画像は正常に復元されました。</translation>
+</phrase>
+
+<!-- pdUndo.cls contains 3 phrases.  One was a duplicate of an existing phrase, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>hexagon</original>
+<translation>六角形</translation>
+</phrase>
+
+<phrase>
+<original>braid</original>
+<translation>ブレード</translation>
+</phrase>
+
+<phrase>
+<original>cross</original>
+<translation>クロス</translation>
+</phrase>
+
+<phrase>
+<original>leaves</original>
+<translation>葉</translation>
+</phrase>
+
+<phrase>
+<original>ragged</original>
+<translation>おぞい</translation>
+</phrase>
+
+<!-- pdVoronoi.cls contains 22 phrases. 17 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<!-- pdWebP.cls contains 3 phrases.  All were duplicates of existing phrases, so no new phrases were written to file. -->
+
+<phrase>
+<original>quick start</original>
+<translation>クイック スタート</translation>
+</phrase>
+
+<phrase>
+<original>recent images</original>
+<translation>最近使った画像</translation>
+</phrase>
+
+<phrase>
+<original>clear recent image list</original>
+<translation>最近使った画像リストをクリア</translation>
+</phrase>
+
+<phrase>
+<original>show recent images, if any</original>
+<translation>最近使った画像があれば表示</translation>
+</phrase>
+
+<phrase>
+<original>Open image</original>
+<translation>画像を開く</translation>
+</phrase>
+
+<phrase>
+<original>Import from clipboard</original>
+<translation>クリップボードからインポート</translation>
+</phrase>
+
+<phrase>
+<original>Batch process</original>
+<translation>バッチ処理</translation>
+</phrase>
+
+<phrase>
+<original>Mouse Wheel = VERTICAL SCROLL,  Shift + Wheel = HORIZONTAL SCROLL,  Ctrl + Wheel = ZOOM</original>
+<translation>マウス ホイール = 垂直スクロール、Shif + ホイール = 水平スクロール、Ctrl + ホイール = ズーム</translation>
+</phrase>
+
+<phrase>
+<original>Action canceled: target layer isn't visible.</original>
+<translation>アクションがキャンセルされました: 対象レイヤーが表示されていません。</translation>
+</phrase>
+
+<phrase>
+<original>Open location in Explorer</original>
+<translation>エクスプローラーで場所を開く</translation>
+</phrase>
+
+<phrase>
+<original>Close all except this</original>
+<translation>これ以外を閉じる</translation>
+</phrase>
+
+<phrase>
+<original>Center the image inside the viewport</original>
+<translation>ビューポート内の画像を中央に配置</translation>
+</phrase>
+
+<!-- pdCanvas.ctl contains 20 phrases. 8 were duplicates of existing phrases, so only 12 new phrases were written to file. -->
+
+<phrase>
+<original>caption</original>
+<translation>キャプション</translation>
+</phrase>
+
+<!-- pdCheckBox.ctl contains 1 phrase.  The phrase was unique, so 1 new phrase was written to file. -->
+
+<phrase>
+<original>compositing color</original>
+<translation>合成カラー</translation>
+</phrase>
+
+<phrase>
+<original>depth</original>
+<translation>深さ</translation>
+</phrase>
+
+<phrase>
+<original>transparency format</original>
+<translation>透明度フォーマット</translation>
+</phrase>
+
+<phrase>
+<original>color format</original>
+<translation>カラーフォーマット</translation>
+</phrase>
+
+<phrase>
+<original>palette size</original>
+<translation>パレットサイズ</translation>
+</phrase>
+
+<phrase>
+<original>transparent color</original>
+<translation>透明色</translation>
+</phrase>
+
+<phrase>
+<original>transparency cut-off</original>
+<translation>透明度カット オフ</translation>
+</phrase>
+
+<phrase>
+<original>original file settings</original>
+<translation>元のファイル設定</translation>
+</phrase>
+
+<phrase>
+<original>auto</original>
+<translation>オート</translation>
+</phrase>
+
+<phrase>
+<original>grayscale</original>
+<translation>グレースケール</translation>
+</phrase>
+
+<phrase>
+<original>standard</original>
+<translation>標準</translation>
+</phrase>
+
+<phrase>
+<original>indexed</original>
+<translation>インデックス付き</translation>
+</phrase>
+
+<phrase>
+<original>monochrome</original>
+<translation>モノクロ</translation>
+</phrase>
+
+<phrase>
+<original>full</original>
+<translation>フル</translation>
+</phrase>
+
+<phrase>
+<original>binary (by cut-off)</original>
+<translation>バイナリ (カット オフ)</translation>
+</phrase>
+
+<phrase>
+<original>binary (by color)</original>
+<translation>バイナリ (色別)</translation>
+</phrase>
+
+<phrase>
+<original>none</original>
+<translation>なし</translation>
+</phrase>
+
+<!-- pdColorDepth.ctl contains 24 phrases. 7 were duplicates of existing phrases, so only 17 new phrases were written to file. -->
+
+<phrase>
+<original>RGB(%1, %2, %3)</original>
+<translation>Rgb(%1, %2, %3)</translation>
+</phrase>
+
+<phrase>
+<original>Click to enter a full color selection screen.</original>
+<translation>クリックすると、色の選択画面になります。</translation>
+</phrase>
+
+<phrase>
+<original>Active color</original>
+<translation>アクティブ色</translation>
+</phrase>
+
+<phrase>
+<original>Click to make the main screen's paint color the active color.</original>
+<translation>クリックすると、メイン画面の描画色がアクティブ色として選択されます。</translation>
+</phrase>
+
+<phrase>
+<original>Main screen paint color</original>
+<translation>メイン画面の描画色</translation>
+</phrase>
+
+<!-- pdColorSelector.ctl contains 10 phrases. 5 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<phrase>
+<original>Current color</original>
+<translation>現在の色</translation>
+</phrase>
+
+<phrase>
+<original>Rotate hue clockwise</original>
+<translation>色相を時計回りに回転</translation>
+</phrase>
+
+<phrase>
+<original>Increase saturation</original>
+<translation>彩度を上げる</translation>
+</phrase>
+
+<phrase>
+<original>Increase luminance</original>
+<translation>輝度を上げる</translation>
+</phrase>
+
+<phrase>
+<original>Increase red</original>
+<translation>赤を上げる</translation>
+</phrase>
+
+<phrase>
+<original>Increase green</original>
+<translation>緑を上げる</translation>
+</phrase>
+
+<phrase>
+<original>Increase blue</original>
+<translation>青を上げる</translation>
+</phrase>
+
+<phrase>
+<original>Decrease luminance</original>
+<translation>明度を下げる</translation>
+</phrase>
+
+<phrase>
+<original>Decrease saturation</original>
+<translation>明度を下げる</translation>
+</phrase>
+
+<phrase>
+<original>Rotate hue counterclockwise</original>
+<translation>色相を反時計回りに回転</translation>
+</phrase>
+
+<phrase>
+<original>Decrease blue</original>
+<translation>青を下げる</translation>
+</phrase>
+
+<phrase>
+<original>Decrease green</original>
+<translation>緑を下げる</translation>
+</phrase>
+
+<phrase>
+<original>Decrease red</original>
+<translation>赤を下げる</translation>
+</phrase>
+
+<!-- pdColorVariants.ctl contains 28 phrases. 15 were duplicates of existing phrases, so only 13 new phrases were written to file. -->
+
+<!-- pdColorWheel.ctl contains 2 phrases.  All were duplicates of existing phrases, so no new phrases were written to file. -->
+
+<phrase>
+<original>OK</original>
+<translation>OK</translation>
+</phrase>
+
+<phrase>
+<original>Cancel</original>
+<translation>キャンセル</translation>
+</phrase>
+
+<phrase>
+<original>Saving preset</original>
+<translation>プリセットの保存</translation>
+</phrase>
+
+<phrase>
+<original>Preset saved.</original>
+<translation>プリセットが保存されました。</translation>
+</phrase>
+
+<phrase>
+<original>Preset save canceled.</original>
+<translation>プリセット保存をキャンセルしました。</translation>
+</phrase>
+
+<phrase>
+<original>last-used settings</original>
+<translation>最後に使用した設定</translation>
+</phrase>
+
+<phrase>
+<original>This button will open a new issue page in your web browser.  You will need a GitHub account to proceed.</original>
+<translation>このボタンをクリックすると、ウェブブラウザに新しい issue ページが開きます。  次に進むには GitHub アカウントが必要です。</translation>
+</phrase>
+
+<phrase>
+<original>Submit bug report or feedback</original>
+<translation>バグ レポートまたはフィードバックの提出</translation>
+</phrase>
+
+<!-- pdCommandBar.ctl contains 9 phrases.  One was a duplicate of an existing phrase, so only 8 new phrases were written to file. -->
+
+<!-- pdCommandBarMini.ctl contains 3 phrases.  All were duplicates of existing phrases, so no new phrases were written to file. -->
+
+<phrase>
+<original>before</original>
+<translation>適用前</translation>
+</phrase>
+
+<phrase>
+<original>after</original>
+<translation>適用後</translation>
+</phrase>
+
+<phrase>
+<original>1:1</original>
+<translation>1:1</translation>
+</phrase>
+
+<phrase>
+<original>fit</original>
+<translation>フィット</translation>
+</phrase>
+
+<!-- pdFxPreview.ctl contains 4 phrases.  All 4 were unique, so 4 new phrases were written to file. -->
+
+<!-- pdHyperlink.ctl contains 1 phrase.  One was a duplicate of an existing phrase, so only 0 new phrases were written to file. -->
+
+<phrase>
+<original>Once this image has been saved to disk, its filename will appear here.</original>
+<translation>この画像がディスクに保存されると、ファイル名がここに表示されます。</translation>
+</phrase>
+
+<phrase>
+<original>This image does not have a filename.</original>
+<translation>この画像にはファイル名がありません。</translation>
+</phrase>
+
+<phrase>
+<original>Hover an image thumbnail to see its name and current file location.</original>
+<translation>画像のサムネイルにカーソルを合わせると、名前と現在のファイルの場所が表示されます。</translation>
+</phrase>
+
+<!-- pdImageStrip.ctl contains 3 phrases.  All 3 were unique, so 3 new phrases were written to file. -->
+
+<!-- pdLabel.ctl contains 1 phrase.  One was a duplicate of an existing phrase, so only 0 new phrases were written to file. -->
+
+<phrase>
+<original>Rearrange layers</original>
+<translation>レイヤーの再配置</translation>
+</phrase>
+
+<!-- pdLayerListInner.ctl contains 9 phrases. 8 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>general metadata settings</original>
+<translation>一般的なメタデータの設定</translation>
+</phrase>
+
+<phrase>
+<original>review metadata before saving</original>
+<translation>保存する前にメタデータを確認</translation>
+</phrase>
+
+<phrase>
+<original>copy all relevant metadata to the new file</original>
+<translation>関連するすべてのメタデータを新しいファイルにコピー</translation>
+</phrase>
+
+<phrase>
+<original>erase tags that might be personal (including GPS and location)</original>
+<translation>個人情報の可能性があるタグを消去 (GPS や位置情報を含む)</translation>
+</phrase>
+
+<phrase>
+<original>embed thumbnail image</original>
+<translation>サムネイル画像を埋め込む</translation>
+</phrase>
+
+<phrase>
+<original>This image contains metadata.</original>
+<translation>この画像にはメタデータが含まれています。</translation>
+</phrase>
+
+<phrase>
+<original>JPEG-specific settings</original>
+<translation>JPEG 固有の設定</translation>
+</phrase>
+
+<!-- pdMetadataExport.ctl contains 14 phrases. 7 were duplicates of existing phrases, so only 7 new phrases were written to file. -->
+
+<phrase>
+<original>Current frame: %1 of %2</original>
+<translation>現在のフレーム: %1 / %2</translation>
+</phrase>
+
+<phrase>
+<original>%1 of %2</original>
+<translation>%1 / %2</translation>
+</phrase>
+
+<!-- pdNavigator.ctl contains 4 phrases. 2 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>new</original>
+<translation>新規</translation>
+</phrase>
+
+<phrase>
+<original>original</original>
+<translation>元</translation>
+</phrase>
+
+<!-- pdNewOld.ctl contains 4 phrases. 2 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>RGBA(%1, %2, %3, %4)</original>
+<translation>RGBA(%1, %2, %3, %4)</translation>
+</phrase>
+
+<phrase>
+<original>index %1</original>
+<translation>インデックス %1</translation>
+</phrase>
+
+<!-- pdPaletteUI.ctl contains 6 phrases. 4 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<!-- pdRadioButton.ctl contains 1 phrase.  One was a duplicate of an existing phrase, so only 0 new phrases were written to file. -->
+
+<phrase>
+<original>resolution</original>
+<translation>解像度</translation>
+</phrase>
+
+<phrase>
+<original>dimensions</original>
+<translation>寸法</translation>
+</phrase>
+
+<phrase>
+<original>aspect ratio</original>
+<translation>アスペクト比</translation>
+</phrase>
+
+<phrase>
+<original>The final width and height measurements must be between 1 and 32760 pixels.</original>
+<translation>最終的な幅と高さの寸法は、1から32760ピクセルの間でなければなりません。</translation>
+</phrase>
+
+<phrase>
+<original>Invalid measurement</original>
+<translation>無効な測定</translation>
+</phrase>
+
+<phrase>
+<original>Preserve aspect ratio (sometimes called Constrain Proportions).  Use this option to resize an image while keeping the width and height in sync.</original>
+<translation>アスペクト比を保持 (Constrain Proportionsと呼ばれることもあります)。  このオプションを使うと、幅と高さを同期させたまま画像のサイズを変更できます。</translation>
+</phrase>
+
+<phrase>
+<original>Preserve aspect ratio</original>
+<translation>アスペクト比を保つ</translation>
+</phrase>
+
+<phrase>
+<original>Change the unit of measurement used to resize the image.</original>
+<translation>画像のサイズ変更に使用する単位を変更します。</translation>
+</phrase>
+
+<phrase>
+<original>Change the unit of measurement used for image resolution (pixel density).</original>
+<translation>画像解像度 (ピクセル密度)の単位を変更します。</translation>
+</phrase>
+
+<phrase>
+<original>pixels / inch (PPI)</original>
+<translation>ピクセル/インチ (PPI)</translation>
+</phrase>
+
+<phrase>
+<original>pixels / centimeter (PPCM)</original>
+<translation>ピクセル/センチメートル (PPCM)</translation>
+</phrase>
+
+<phrase>
+<original>exact aspect ratio will vary by image</original>
+<translation>正確な縦横比は画像によって異なります</translation>
+</phrase>
+
+<phrase>
+<original>exact size will vary by image</original>
+<translation>正確なサイズは画像によって異なります。</translation>
+</phrase>
+
+<phrase>
+<original>%1, was %2</original>
+<translation>%1、%2 だった</translation>
+</phrase>
+
+<!-- pdResize.ctl contains 38 phrases. 24 were duplicates of existing phrases, so only 14 new phrases were written to file. -->
+
+<phrase>
+<original>Scroll here</original>
+<translation>ここをスクロール</translation>
+</phrase>
+
+<phrase>
+<original>Left edge</original>
+<translation>左端</translation>
+</phrase>
+
+<phrase>
+<original>Right edge</original>
+<translation>右端</translation>
+</phrase>
+
+<phrase>
+<original>Top</original>
+<translation>上</translation>
+</phrase>
+
+<phrase>
+<original>Bottom</original>
+<translation>下</translation>
+</phrase>
+
+<phrase>
+<original>Page left</original>
+<translation>左ページ</translation>
+</phrase>
+
+<phrase>
+<original>Page right</original>
+<translation>ページ右</translation>
+</phrase>
+
+<phrase>
+<original>Page up</original>
+<translation>ページアップ</translation>
+</phrase>
+
+<phrase>
+<original>Page down</original>
+<translation>ページダウン</translation>
+</phrase>
+
+<phrase>
+<original>Scroll left</original>
+<translation>左スクロール</translation>
+</phrase>
+
+<phrase>
+<original>Scroll right</original>
+<translation>右スクロール</translation>
+</phrase>
+
+<phrase>
+<original>Scroll up</original>
+<translation>上にスクロール</translation>
+</phrase>
+
+<phrase>
+<original>Scroll down</original>
+<translation>下にスクロール</translation>
+</phrase>
+
+<!-- pdScrollBar.ctl contains 26 phrases. 13 were duplicates of existing phrases, so only 13 new phrases were written to file. -->
+
+<phrase>
+<original>%1 = %2</original>
+<translation>%1 = %2</translation>
+</phrase>
+
+<phrase>
+<original>"%1" produces an out of range result (%2).
+The final value must be between %3 and %4.</original>
+<translation>"%1" は範囲外の結果 (%2) を生成します。
+最終値は %3 から %4 の間でなければならない。</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon doesn't understand the expression: %1</original>
+<translation>PhotoDemon は式を理解しません:  %1</translation>
+</phrase>
+
+<!-- pdSpinner.ctl contains 20 phrases. 17 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>size</original>
+<translation>サイズ</translation>
+</phrase>
+
+<phrase>
+<original>Fit the image on-screen</original>
+<translation>画像を画面に合わせる</translation>
+</phrase>
+
+<phrase>
+<original>Zoom in</original>
+<translation>ズーム イン</translation>
+</phrase>
+
+<phrase>
+<original>Zoom out</original>
+<translation>ズーム アウト</translation>
+</phrase>
+
+<phrase>
+<original>Change viewport zoom</original>
+<translation>ビューポートのズームを変更</translation>
+</phrase>
+
+<phrase>
+<original>Change the image size unit displayed to the left of this box</original>
+<translation>このボックスの左に表示される画像サイズの単位を変更</translation>
+</phrase>
+
+<!-- pdStatusBar.ctl contains 8 phrases. 2 were duplicates of existing phrases, so only 6 new phrases were written to file. -->
+
+<phrase>
+<original>PhotoDemon by Tanner Helland - www.PhotoDemon.org</original>
+<translation>PhotoDemon by Tanner Helland - www.PhotoDemon.org</translation>
+</phrase>
+
+<phrase>
+<original>New</original>
+<translation>新規作成</translation>
+</phrase>
+
+<phrase>
+<original>Open recent</original>
+<translation>最近使ったファイル</translation>
+</phrase>
+
+<phrase>
+<original>Import</original>
+<translation>インポート</translation>
+</phrase>
+
+<phrase>
+<original>From clipboard</original>
+<translation>クリップボードから</translation>
+</phrase>
+
+<phrase>
+<original>From scanner or camera</original>
+<translation>スキャナー/カメラから</translation>
+</phrase>
+
+<phrase>
+<original>Select which scanner or camera to use</original>
+<translation>使用するスキャナーまたはカメラを選択</translation>
+</phrase>
+
+<phrase>
+<original>Online image</original>
+<translation>オンラインの画像</translation>
+</phrase>
+
+<phrase>
+<original>Screenshot</original>
+<translation>スクリーンショット</translation>
+</phrase>
+
+<phrase>
+<original>Save copy (lossless)</original>
+<translation>コピーを保存 (ロスレス)</translation>
+</phrase>
+
+<phrase>
+<original>Export</original>
+<translation>エクスポート</translation>
+</phrase>
+
+<phrase>
+<original>Animated GIF</original>
+<translation>アニメーションGIF</translation>
+</phrase>
+
+<phrase>
+<original>Animated PNG</original>
+<translation>アニメーションPNG</translation>
+</phrase>
+
+<phrase>
+<original>Animated WebP</original>
+<translation>アニメーションWebP</translation>
+</phrase>
+
+<phrase>
+<original>Color profile</original>
+<translation>カラー プロファイル</translation>
+</phrase>
+
+<phrase>
+<original>Batch operations</original>
+<translation>バッチ処理</translation>
+</phrase>
+
+<phrase>
+<original>Process</original>
+<translation>処理</translation>
+</phrase>
+
+<phrase>
+<original>Repair</original>
+<translation>修復</translation>
+</phrase>
+
+<phrase>
+<original>Exit</original>
+<translation>終了</translation>
+</phrase>
+
+<phrase>
+<original>Edit</original>
+<translation>編集</translation>
+</phrase>
+
+<phrase>
+<original>Special</original>
+<translation>特殊</translation>
+</phrase>
+
+<phrase>
+<original>Image</original>
+<translation>画像</translation>
+</phrase>
+
+<phrase>
+<original>Duplicate</original>
+<translation>複製</translation>
+</phrase>
+
+<phrase>
+<original>Resize</original>
+<translation>リサイズ</translation>
+</phrase>
+
+<phrase>
+<original>Content-aware resize</original>
+<translation>コンテンツに応じたリサイズ</translation>
+</phrase>
+
+<phrase>
+<original>Crop to selection</original>
+<translation>選択範囲で切り抜き</translation>
+</phrase>
+
+<phrase>
+<original>Trim empty borders</original>
+<translation>余白をトリミング</translation>
+</phrase>
+
+<phrase>
+<original>Straighten</original>
+<translation>傾き補正</translation>
+</phrase>
+
+<phrase>
+<original>Rotate 90 clockwise</original>
+<translation>時計回りに90度回転</translation>
+</phrase>
+
+<phrase>
+<original>Rotate 90 counter-clockwise</original>
+<translation>反時計回りに90度回転</translation>
+</phrase>
+
+<phrase>
+<original>Rotate 180</original>
+<translation>180度回転</translation>
+</phrase>
+
+<phrase>
+<original>Rotate arbitrary</original>
+<translation>任意の回転</translation>
+</phrase>
+
+<phrase>
+<original>Flip horizontal</original>
+<translation>左右反転</translation>
+</phrase>
+
+<phrase>
+<original>Flip vertical</original>
+<translation>上下反転</translation>
+</phrase>
+
+<phrase>
+<original>Animation</original>
+<translation>アニメーション</translation>
+</phrase>
+
+<phrase>
+<original>Compare</original>
+<translation>比較</translation>
+</phrase>
+
+<phrase>
+<original>Similarity</original>
+<translation>類似性</translation>
+</phrase>
+
+<phrase>
+<original>Metadata</original>
+<translation>メタデータ</translation>
+</phrase>
+
+<phrase>
+<original>Map photo location</original>
+<translation>地図写真の場所</translation>
+</phrase>
+
+<phrase>
+<original>Layer</original>
+<translation>レイヤー</translation>
+</phrase>
+
+<phrase>
+<original>Add</original>
+<translation>追加</translation>
+</phrase>
+
+<phrase>
+<original>Basic layer</original>
+<translation>基本レイヤー</translation>
+</phrase>
+
+<phrase>
+<original>Duplicate of current layer</original>
+<translation>現在のレイヤーから複製</translation>
+</phrase>
+
+<phrase>
+<original>From file</original>
+<translation>ファイルから</translation>
+</phrase>
+
+<phrase>
+<original>From visible layers</original>
+<translation>表示レイヤーから</translation>
+</phrase>
+
+<phrase>
+<original>Delete</original>
+<translation>削除</translation>
+</phrase>
+
+<phrase>
+<original>Current layer</original>
+<translation>現在のレイヤー</translation>
+</phrase>
+
+<phrase>
+<original>Hidden layers</original>
+<translation>非表示のレイヤー</translation>
+</phrase>
+
+<phrase>
+<original>Replace</original>
+<translation>置換</translation>
+</phrase>
+
+<phrase>
+<original>Merge up</original>
+<translation>上と結合</translation>
+</phrase>
+
+<phrase>
+<original>Merge down</original>
+<translation>下と結合</translation>
+</phrase>
+
+<phrase>
+<original>Order</original>
+<translation>順序</translation>
+</phrase>
+
+<phrase>
+<original>Move layer to top</original>
+<translation>レイヤーを最上層へ移動</translation>
+</phrase>
+
+<phrase>
+<original>Move layer up</original>
+<translation>レイヤーを上へ移動</translation>
+</phrase>
+
+<phrase>
+<original>Move layer down</original>
+<translation>レイヤーを下へ移動</translation>
+</phrase>
+
+<phrase>
+<original>Move layer to bottom</original>
+<translation>レイヤーを最下層へ移動</translation>
+</phrase>
+
+<phrase>
+<original>Reverse</original>
+<translation>反転</translation>
+</phrase>
+
+<phrase>
+<original>Visibility</original>
+<translation>表示</translation>
+</phrase>
+
+<phrase>
+<original>Show this layer</original>
+<translation>このレイヤーを表示</translation>
+</phrase>
+
+<phrase>
+<original>Fit to canvas</original>
+<translation>キャンバスに合わせる</translation>
+</phrase>
+
+<phrase>
+<original>Orientation</original>
+<translation>方向</translation>
+</phrase>
+
+<phrase>
+<original>Size</original>
+<translation>サイズ</translation>
+</phrase>
+
+<phrase>
+<original>Reset to actual size</original>
+<translation>実際のサイズにリセット</translation>
+</phrase>
+
+<phrase>
+<original>Fit to image</original>
+<translation>画像にフィット</translation>
+</phrase>
+
+<phrase>
+<original>Transparency</original>
+<translation>透過</translation>
+</phrase>
+
+<phrase>
+<original>From color (chroma key)</original>
+<translation>色から (クロマキー)</translation>
+</phrase>
+
+<phrase>
+<original>From luminance</original>
+<translation>輝度から</translation>
+</phrase>
+
+<phrase>
+<original>Remove transparency</original>
+<translation>透過を削除</translation>
+</phrase>
+
+<phrase>
+<original>Threshold</original>
+<translation>しきい値</translation>
+</phrase>
+
+<phrase>
+<original>Rasterize</original>
+<translation>ラスタライズ</translation>
+</phrase>
+
+<phrase>
+<original>All layers</original>
+<translation>すべてのレイヤー</translation>
+</phrase>
+
+<phrase>
+<original>Split</original>
+<translation>分割</translation>
+</phrase>
+
+<phrase>
+<original>Current layer into standalone image</original>
+<translation>現在のレイヤーを独立した画像にする</translation>
+</phrase>
+
+<phrase>
+<original>All layers into standalone images</original>
+<translation>すべてのレイヤーを独立した画像にする</translation>
+</phrase>
+
+<phrase>
+<original>Other open images into this image (as layers)</original>
+<translation>他の開いている画像をこの画像に入れる (レイヤーとして)</translation>
+</phrase>
+
+<phrase>
+<original>Select</original>
+<translation>選択</translation>
+</phrase>
+
+<phrase>
+<original>All</original>
+<translation>すべて</translation>
+</phrase>
+
+<phrase>
+<original>Invert</original>
+<translation>反転</translation>
+</phrase>
+
+<phrase>
+<original>Grow</original>
+<translation>拡張</translation>
+</phrase>
+
+<phrase>
+<original>Shrink</original>
+<translation>収縮</translation>
+</phrase>
+
+<phrase>
+<original>Border</original>
+<translation>縁取り選択</translation>
+</phrase>
+
+<phrase>
+<original>Feather</original>
+<translation>境界をぼかす</translation>
+</phrase>
+
+<phrase>
+<original>Save current selection</original>
+<translation>選択範囲を保存</translation>
+</phrase>
+
+<phrase>
+<original>Selected area as image</original>
+<translation>画像として選択された領域</translation>
+</phrase>
+
+<phrase>
+<original>Selection mask as image</original>
+<translation>画像としての選択マスク</translation>
+</phrase>
+
+<phrase>
+<original>Adjustments</original>
+<translation>調整</translation>
+</phrase>
+
+<phrase>
+<original>Channels</original>
+<translation>チャンネル</translation>
+</phrase>
+
+<phrase>
+<original>Shift left</original>
+<translation>左シフト</translation>
+</phrase>
+
+<phrase>
+<original>Shift right</original>
+<translation>右シフト</translation>
+</phrase>
+
+<phrase>
+<original>Histogram</original>
+<translation>ヒストグラム</translation>
+</phrase>
+
+<phrase>
+<original>Display</original>
+<translation>ディスプレイ</translation>
+</phrase>
+
+<phrase>
+<original>Stretch</original>
+<translation>ストレッチ</translation>
+</phrase>
+
+<phrase>
+<original>CMYK (film negative)</original>
+<translation>CMYK (ネガ フィルム)</translation>
+</phrase>
+
+<phrase>
+<original>RGB</original>
+<translation>RGB</translation>
+</phrase>
+
+<phrase>
+<original>Lighting</original>
+<translation>照明</translation>
+</phrase>
+
+<phrase>
+<original>Map</original>
+<translation>マップ</translation>
+</phrase>
+
+<phrase>
+<original>Monochrome</original>
+<translation>モノクローム</translation>
+</phrase>
+
+<phrase>
+<original>Effects</original>
+<translation>エフェクト</translation>
+</phrase>
+
+<phrase>
+<original>Artistic</original>
+<translation>芸術的</translation>
+</phrase>
+
+<phrase>
+<original>Figured glass (dents)</original>
+<translation>フィギュアド グラス (へこみ)</translation>
+</phrase>
+
+<phrase>
+<original>Blur</original>
+<translation>ぼかし</translation>
+</phrase>
+
+<phrase>
+<original>Distort</original>
+<translation>歪み</translation>
+</phrase>
+
+<phrase>
+<original>Correct existing distortion</original>
+<translation>既存の歪みを補正</translation>
+</phrase>
+
+<phrase>
+<original>Lens</original>
+<translation>レンズ</translation>
+</phrase>
+
+<phrase>
+<original>Miscellaneous</original>
+<translation>その他</translation>
+</phrase>
+
+<phrase>
+<original>Edge</original>
+<translation>エッジ</translation>
+</phrase>
+
+<phrase>
+<original>Light and shadow</original>
+<translation>光と影</translation>
+</phrase>
+
+<phrase>
+<original>Dilate</original>
+<translation>広げる</translation>
+</phrase>
+
+<phrase>
+<original>Erode</original>
+<translation>侵食</translation>
+</phrase>
+
+<phrase>
+<original>Natural</original>
+<translation>自然</translation>
+</phrase>
+
+<phrase>
+<original>Underwater</original>
+<translation>水中</translation>
+</phrase>
+
+<phrase>
+<original>Noise</original>
+<translation>ノイズ</translation>
+</phrase>
+
+<phrase>
+<original>Pixelate</original>
+<translation>ピクセレート</translation>
+</phrase>
+
+<phrase>
+<original>Render</original>
+<translation>レンダー</translation>
+</phrase>
+
+<phrase>
+<original>Stylize</original>
+<translation>スタイライズ</translation>
+</phrase>
+
+<phrase>
+<original>Kuwahara</original>
+<translation>桑原</translation>
+</phrase>
+
+<phrase>
+<original>Transform</original>
+<translation>変形</translation>
+</phrase>
+
+<phrase>
+<original>Foreground</original>
+<translation>前景</translation>
+</phrase>
+
+<phrase>
+<original>Playback speed</original>
+<translation>再生速度</translation>
+</phrase>
+
+<phrase>
+<original>Tools</original>
+<translation>ツール</translation>
+</phrase>
+
+<phrase>
+<original>Language</original>
+<translation>言語 (Language)</translation>
+</phrase>
+
+<phrase>
+<original>English (US)</original>
+<translation>英語</translation>
+</phrase>
+
+<phrase>
+<original>Language editor</original>
+<translation>言語エディター</translation>
+</phrase>
+
+<phrase>
+<original>Theme</original>
+<translation>テーマ</translation>
+</phrase>
+
+<phrase>
+<original>Create macro</original>
+<translation>マクロを作成</translation>
+</phrase>
+
+<phrase>
+<original>From history</original>
+<translation>履歴から</translation>
+</phrase>
+
+<phrase>
+<original>Start recording</original>
+<translation>記録を開始</translation>
+</phrase>
+
+<phrase>
+<original>Stop recording</original>
+<translation>記録を停止</translation>
+</phrase>
+
+<phrase>
+<original>Recent macros</original>
+<translation>最近使ったマクロ</translation>
+</phrase>
+
+<phrase>
+<original>Animated screen capture</original>
+<translation>アニメーション画面キャプチャ</translation>
+</phrase>
+
+<phrase>
+<original>Options</original>
+<translation>オプション</translation>
+</phrase>
+
+<phrase>
+<original>Third-party libraries</original>
+<translation>サード パーティーのライブラリ</translation>
+</phrase>
+
+<phrase>
+<original>Developers</original>
+<translation>開発者</translation>
+</phrase>
+
+<phrase>
+<original>Theme editor</original>
+<translation>テーマ エディター</translation>
+</phrase>
+
+<phrase>
+<original>Build theme package</original>
+<translation>テーマ パッケージのビルド</translation>
+</phrase>
+
+<phrase>
+<original>Build standalone package</original>
+<translation>スタンド アロン パッケージのビルド</translation>
+</phrase>
+
+<phrase>
+<original>Test</original>
+<translation>テスト</translation>
+</phrase>
+
+<phrase>
+<original>View</original>
+<translation>表示</translation>
+</phrase>
+
+<phrase>
+<original>Fit image on screen</original>
+<translation>画面に画像を合わせる</translation>
+</phrase>
+
+<phrase>
+<original>Zoom to value</original>
+<translation>ズーム倍率</translation>
+</phrase>
+
+<phrase>
+<original>1:1 (actual size, 100%)</original>
+<translation>1:1 (実寸、100%)</translation>
+</phrase>
+
+<phrase>
+<original>Show rulers</original>
+<translation>ルーラーを表示</translation>
+</phrase>
+
+<phrase>
+<original>Show status bar</original>
+<translation>ステータス バーを表示</translation>
+</phrase>
+
+<phrase>
+<original>Window</original>
+<translation>ウインドウ</translation>
+</phrase>
+
+<phrase>
+<original>Toolbox</original>
+<translation>ツール ボックス</translation>
+</phrase>
+
+<phrase>
+<original>Display toolbox</original>
+<translation>ツール ボックスを表示</translation>
+</phrase>
+
+<phrase>
+<original>Display tool category titles</original>
+<translation>ツール カテゴリーのタイトルを表示</translation>
+</phrase>
+
+<phrase>
+<original>Small buttons</original>
+<translation>小さいボタン</translation>
+</phrase>
+
+<phrase>
+<original>Medium buttons</original>
+<translation>中サイズのボタン</translation>
+</phrase>
+
+<phrase>
+<original>Large buttons</original>
+<translation>大きいボタン</translation>
+</phrase>
+
+<phrase>
+<original>Tool options</original>
+<translation>ツール オプション</translation>
+</phrase>
+
+<phrase>
+<original>Layers</original>
+<translation>レイヤー</translation>
+</phrase>
+
+<phrase>
+<original>Image tabstrip</original>
+<translation>画像のタブ</translation>
+</phrase>
+
+<phrase>
+<original>Always show</original>
+<translation>常に表示</translation>
+</phrase>
+
+<phrase>
+<original>Show when multiple images are loaded</original>
+<translation>複数の画像を読み込んだときに表示</translation>
+</phrase>
+
+<phrase>
+<original>Never show</original>
+<translation>表示しない</translation>
+</phrase>
+
+<phrase>
+<original>Left</original>
+<translation>左</translation>
+</phrase>
+
+<phrase>
+<original>Right</original>
+<translation>右</translation>
+</phrase>
+
+<phrase>
+<original>Reset all toolboxes</original>
+<translation>すべてのツール ボックスをリセット</translation>
+</phrase>
+
+<phrase>
+<original>Next image</original>
+<translation>次の画像</translation>
+</phrase>
+
+<phrase>
+<original>Previous image</original>
+<translation>前の画像</translation>
+</phrase>
+
+<phrase>
+<original>Help</original>
+<translation>ヘルプ</translation>
+</phrase>
+
+<phrase>
+<original>Support us on Patreon</original>
+<translation>パトロンで支援する</translation>
+</phrase>
+
+<phrase>
+<original>Support us with a one-time donation</original>
+<translation>1回限りの寄付で支援する</translation>
+</phrase>
+
+<phrase>
+<original>Ask a question</original>
+<translation>質問する</translation>
+</phrase>
+
+<phrase>
+<original>Check for updates</original>
+<translation>更新を確認する</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon forum</original>
+<translation>PhotoDemon フォーラム</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon license and terms of use</original>
+<translation>PhotoDemon のライセンスおよび使用条件</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon source code</original>
+<translation>PhotoDemon ソース コード</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon website</original>
+<translation>PhotoDemon ウェブサイト</translation>
+</phrase>
+
+<phrase>
+<original>About</original>
+<translation>このアプリケーションについて</translation>
+</phrase>
+
+<phrase>
+<original>A new version of PhotoDemon is available.  The update is automatically processing in the background</original>
+<translation>PhotoDemon の新しいバージョンが利用可能です。  アップデートはバックグラウンドで自動的に処理されます。</translation>
+</phrase>
+
+<phrase>
+<original>A new version of PhotoDemon is available!
+
+The update is automatically processing in the background.  You will receive a new notification when it completes.</original>
+<translation>PhotoDemon の新しいバージョンが利用可能です!
+
+アップデートはバックグラウンドで自動的に処理されます。  完了すると、新しい通知が届きます。</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon Updates</original>
+<translation>PhotoDemon 最新情報</translation>
+</phrase>
+
+<phrase>
+<original>This copy of PhotoDemon is up to date.</original>
+<translation>この PhotoDemon のコピーは最新版です。</translation>
+</phrase>
+
+<phrase>
+<original>This copy of PhotoDemon is the newest version available.
+
+(Current version: %1.%2.%3)</original>
+<translation>この PhotoDemon のコピーは、利用可能な最新バージョンです。
+
+(現在のバージョン: %1.%2.%3)</translation>
+</phrase>
+
+<phrase>
+<original>Updates unavailable</original>
+<translation>アップデート不可</translation>
+</phrase>
+
+<phrase>
+<original>Importing metadata</original>
+<translation>メタデータのインポート</translation>
+</phrase>
+
+<phrase>
+<original>Please wait while the new language is applied</original>
+<translation>新しい言語が適用されるまでお待ちください</translation>
+</phrase>
+
+<phrase>
+<original>Removing existing translation</original>
+<translation>既存の翻訳の削除</translation>
+</phrase>
+
+<phrase>
+<original>Applying new translation</original>
+<translation>新しい翻訳の適用</translation>
+</phrase>
+
+<phrase>
+<original>Language changed successfully.</original>
+<translation>言語を変更しました。</translation>
+</phrase>
+
+<!-- MainWindow.frm contains 394 phrases. 212 were duplicates of existing phrases, so only 182 new phrases were written to file. -->
+
+<phrase>
+<original>Monochrome Conversion</original>
+<translation>モノクロ変換</translation>
+</phrase>
+
+<phrase>
+<original>dithering amount</original>
+<translation>ディザリング量</translation>
+</phrase>
+
+<phrase>
+<original>dithering</original>
+<translation>ディザリング</translation>
+</phrase>
+
+<phrase>
+<original>transparency</original>
+<translation>透明</translation>
+</phrase>
+
+<phrase>
+<original>threshold</original>
+<translation>しきい値</translation>
+</phrase>
+
+<phrase>
+<original>automatically calculate threshold</original>
+<translation>しきい値を自動計算</translation>
+</phrase>
+
+<phrase>
+<original>final colors</original>
+<translation>最終色</translation>
+</phrase>
+
+<phrase>
+<original>do not modify</original>
+<translation>変更しない</translation>
+</phrase>
+
+<phrase>
+<original>remove from image</original>
+<translation>画像から削除</translation>
+</phrase>
+
+<phrase>
+<original>Converting image to two colors</original>
+<translation>画像を2色に変換する</translation>
+</phrase>
+
+<!-- Adjustments_BlackAndWhite.frm contains 11 phrases.  One was a duplicate of an existing phrase, so only 10 new phrases were written to file. -->
+
+<phrase>
+<original>model</original>
+<translation>モデル</translation>
+</phrase>
+
+<phrase>
+<original>sample image for true contrast (slower but more accurate)</original>
+<translation>真のコントラストのためのサンプル画像 (時間はかかるが、より正確)</translation>
+</phrase>
+
+<phrase>
+<original>brightness</original>
+<translation>明るさ</translation>
+</phrase>
+
+<phrase>
+<original>contrast</original>
+<translation>コントラスト</translation>
+</phrase>
+
+<phrase>
+<original>Adjusting brightness and contrast</original>
+<translation>明るさとコントラストの調整</translation>
+</phrase>
+
+<phrase>
+<original>modern</original>
+<translation>モダン</translation>
+</phrase>
+
+<phrase>
+<original>legacy</original>
+<translation>レガシー</translation>
+</phrase>
+
+<!-- Adjustments_BrightnessContrast.frm contains 9 phrases. 2 were duplicates of existing phrases, so only 7 new phrases were written to file. -->
+
+<phrase>
+<original>red</original>
+<translation>赤</translation>
+</phrase>
+
+<phrase>
+<original>green</original>
+<translation>緑</translation>
+</phrase>
+
+<phrase>
+<original>blue</original>
+<translation>青</translation>
+</phrase>
+
+<phrase>
+<original>constant</original>
+<translation>不変</translation>
+</phrase>
+
+<phrase>
+<original>preserve luminance</original>
+<translation>輝度を保つ</translation>
+</phrase>
+
+<phrase>
+<original>output channel</original>
+<translation>出力チャンネル</translation>
+</phrase>
+
+<phrase>
+<original>input channel(s)</original>
+<translation>入力チャンネル</translation>
+</phrase>
+
+<phrase>
+<original>options for all channels</original>
+<translation>すべてのチャンネルのオプション</translation>
+</phrase>
+
+<phrase>
+<original>Mixing color channels</original>
+<translation>カラーチャンネルのミキシング</translation>
+</phrase>
+
+<!-- Adjustments_Channel_ChannelMixer.frm contains 15 phrases. 6 were duplicates of existing phrases, so only 9 new phrases were written to file. -->
+
+<phrase>
+<original>color space</original>
+<translation>色空間</translation>
+</phrase>
+
+<phrase>
+<original>channel</original>
+<translation>チャンネル</translation>
+</phrase>
+
+<phrase>
+<original>CMY</original>
+<translation>CMY</translation>
+</phrase>
+
+<phrase>
+<original>CMYK</original>
+<translation>CMYK</translation>
+</phrase>
+
+<phrase>
+<original>cyan</original>
+<translation>シアン</translation>
+</phrase>
+
+<phrase>
+<original>magenta</original>
+<translation>マゼンタ</translation>
+</phrase>
+
+<phrase>
+<original>yellow</original>
+<translation>イエロー</translation>
+</phrase>
+
+<phrase>
+<original>key (black)</original>
+<translation>キー (黒)</translation>
+</phrase>
+
+<phrase>
+<original>Isolating the %1 channel</original>
+<translation>%1 チャネルの分離</translation>
+</phrase>
+
+<!-- Adjustments_Channel_Rechannel.frm contains 32 phrases. 23 were duplicates of existing phrases, so only 9 new phrases were written to file. -->
+
+<phrase>
+<original>new balance</original>
+<translation>ニュー バランス</translation>
+</phrase>
+
+<phrase>
+<original>Adjusting color balance</original>
+<translation>カラー バランスの調整</translation>
+</phrase>
+
+<!-- Adjustments_ColorBalance.frm contains 11 phrases. 9 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>saturation</original>
+<translation>彩度</translation>
+</phrase>
+
+<phrase>
+<original>new color</original>
+<translation>新しい色</translation>
+</phrase>
+
+<phrase>
+<original>Colorizing image</original>
+<translation>画像のカラー化</translation>
+</phrase>
+
+<phrase>
+<original>preserve</original>
+<translation>保持</translation>
+</phrase>
+
+<phrase>
+<original>custom</original>
+<translation>カスタム</translation>
+</phrase>
+
+<!-- Adjustments_Color_Colorize.frm contains 10 phrases. 5 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<phrase>
+<original>number of gray shades</original>
+<translation>グレーシェードの数</translation>
+</phrase>
+
+<phrase>
+<original>style</original>
+<translation>スタイル</translation>
+</phrase>
+
+<phrase>
+<original>Converting image to black and white</original>
+<translation>画像を白黒に変換する</translation>
+</phrase>
+
+<phrase>
+<original>Fastest Calculation (average value)</original>
+<translation>最速計算 (平均値)</translation>
+</phrase>
+
+<phrase>
+<original>Highest Quality (ITU Standard)</original>
+<translation>最高品質 (Itu標準)</translation>
+</phrase>
+
+<phrase>
+<original>Desaturate</original>
+<translation>脱飽和</translation>
+</phrase>
+
+<phrase>
+<original>Decompose</original>
+<translation>分解</translation>
+</phrase>
+
+<phrase>
+<original>Single color channel</original>
+<translation>単色チャンネル</translation>
+</phrase>
+
+<phrase>
+<original>minimum</original>
+<translation>最小</translation>
+</phrase>
+
+<phrase>
+<original>maximum</original>
+<translation>最大</translation>
+</phrase>
+
+<!-- Adjustments_Color_Grayscale.frm contains 17 phrases. 7 were duplicates of existing phrases, so only 10 new phrases were written to file. -->
+
+<phrase>
+<original>Adjust HSL</original>
+<translation>HSL を調整</translation>
+</phrase>
+
+<phrase>
+<original>hue</original>
+<translation>色相</translation>
+</phrase>
+
+<phrase>
+<original>lightness</original>
+<translation>軽さ</translation>
+</phrase>
+
+<phrase>
+<original>Adjusting hue, saturation, and luminance values</original>
+<translation>色相・彩度・明度の調整</translation>
+</phrase>
+
+<!-- Adjustments_Color_HSL.frm contains 6 phrases. 2 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>available LUTs</original>
+<translation>使用可能なLUT</translation>
+</phrase>
+
+<phrase>
+<original>import LUT file</original>
+<translation>LUTファイルのインポート</translation>
+</phrase>
+
+<phrase>
+<original>intensity</original>
+<translation>強度</translation>
+</phrase>
+
+<phrase>
+<original>Applying color lookup</original>
+<translation>カラー ルックアップの適用</translation>
+</phrase>
+
+<phrase>
+<original>%1 is not a valid 3D lookup table (LUT).</original>
+<translation>%1 は有効な 3D ルックアップテーブル (LUT) ではありません。</translation>
+</phrase>
+
+<phrase>
+<original>Your LUT collection is stored in the "%1" folder</original>
+<translation>Lutコレクションは"%1 "フォルダに保存されます。</translation>
+</phrase>
+
+<phrase>
+<original>click to open this folder in Windows Explorer</original>
+<translation>クリックすると、このフォルダがエクスプローラで開きます。</translation>
+</phrase>
+
+<!-- Adjustments_Color_Lookup.frm contains 14 phrases. 7 were duplicates of existing phrases, so only 7 new phrases were written to file. -->
+
+<phrase>
+<original>replace threshold</original>
+<translation>置き換えのしきい値</translation>
+</phrase>
+
+<phrase>
+<original>edge blending</original>
+<translation>境界をブレンド</translation>
+</phrase>
+
+<phrase>
+<original>color to replace (right-click preview to select)</original>
+<translation>置き換える色 (プレビューを右クリックで選択)</translation>
+</phrase>
+
+<phrase>
+<original>Replacing color</original>
+<translation>色を置き換え</translation>
+</phrase>
+
+<!-- Adjustments_Color_ReplaceColor.frm contains 7 phrases. 3 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>strength</original>
+<translation>強さ</translation>
+</phrase>
+
+<phrase>
+<original>Engaging hipsters to perform sepia conversion</original>
+<translation>ヒップスターにセピア変換を依頼</translation>
+</phrase>
+
+<!-- Adjustments_Color_Sepia.frm contains 4 phrases. 2 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>Color temperature</original>
+<translation>色温度</translation>
+</phrase>
+
+<phrase>
+<original>method</original>
+<translation>方法</translation>
+</phrase>
+
+<phrase>
+<original>temperature</original>
+<translation>色温度</translation>
+</phrase>
+
+<phrase>
+<original>warmer</original>
+<translation>ウォーマー</translation>
+</phrase>
+
+<phrase>
+<original>cooler</original>
+<translation>クーラー</translation>
+</phrase>
+
+<phrase>
+<original>new temperature (K)</original>
+<translation>新しい色温度 (K)</translation>
+</phrase>
+
+<phrase>
+<original>cool tones</original>
+<translation>寒色トーン</translation>
+</phrase>
+
+<phrase>
+<original>warm tones</original>
+<translation>暖色トーン</translation>
+</phrase>
+
+<phrase>
+<original>Applying new temperature to image</original>
+<translation>画像に新しい色温度を適用</translation>
+</phrase>
+
+<phrase>
+<original>basic</original>
+<translation>基本</translation>
+</phrase>
+
+<phrase>
+<original>advanced</original>
+<translation>高度</translation>
+</phrase>
+
+<!-- Adjustments_Color_Temperature.frm contains 15 phrases. 4 were duplicates of existing phrases, so only 11 new phrases were written to file. -->
+
+<phrase>
+<original>tint</original>
+<translation>色合い</translation>
+</phrase>
+
+<phrase>
+<original>Re-tinting image</original>
+<translation>画像の再着色</translation>
+</phrase>
+
+<!-- Adjustments_Color_Tint.frm contains 4 phrases. 2 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>vibrance</original>
+<translation>振動</translation>
+</phrase>
+
+<phrase>
+<original>Adjusting color vibrance</original>
+<translation>色の鮮やかさを調整</translation>
+</phrase>
+
+<!-- Adjustments_Color_Vibrance.frm contains 4 phrases. 2 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>display</original>
+<translation>ディスプレイ</translation>
+</phrase>
+
+<phrase>
+<original>histogram overlay</original>
+<translation>ヒストグラム オーバーレイ</translation>
+</phrase>
+
+<phrase>
+<original>grid</original>
+<translation>グリッド</translation>
+</phrase>
+
+<phrase>
+<original>original curve (diagonal line)</original>
+<translation>オリジナル曲線 (対角線)</translation>
+</phrase>
+
+<phrase>
+<original>Applying new curve to image</original>
+<translation>画像に新しいカーブを適用</translation>
+</phrase>
+
+<phrase>
+<original>on</original>
+<translation>オン</translation>
+</phrase>
+
+<phrase>
+<original>off</original>
+<translation>オフ</translation>
+</phrase>
+
+<phrase>
+<original>tool</original>
+<translation>ツール</translation>
+</phrase>
+
+<phrase>
+<original>options</original>
+<translation>オプション</translation>
+</phrase>
+
+<phrase>
+<original>instructions</original>
+<translation>指示</translation>
+</phrase>
+
+<phrase>
+<original>left-click to add new nodes or drag existing nodes</original>
+<translation>左クリックで新しいノードを追加するか、既存のノードをドラッグする</translation>
+</phrase>
+
+<phrase>
+<original>right-click to remove nodes</original>
+<translation>右クリックでノードを削除</translation>
+</phrase>
+
+<phrase>
+<original>input</original>
+<translation>入力</translation>
+</phrase>
+
+<phrase>
+<original>output</original>
+<translation>出力</translation>
+</phrase>
+
+<!-- Adjustments_Curves.frm contains 31 phrases. 17 were duplicates of existing phrases, so only 14 new phrases were written to file. -->
+
+<phrase>
+<original>use logarithmic values</original>
+<translation>対数を使う</translation>
+</phrase>
+
+<phrase>
+<original>fill histogram curves</original>
+<translation>塗りつぶしヒストグラム曲線</translation>
+</phrase>
+
+<phrase>
+<original>visible channels</original>
+<translation>可視チャンネル</translation>
+</phrase>
+
+<phrase>
+<original>statistics</original>
+<translation>統計</translation>
+</phrase>
+
+<phrase>
+<original>(Note: move the mouse over the histogram to calculate these values)</original>
+<translation>(注: これらの値を計算するには、ヒストグラムの上にマウスを移動してください。)</translation>
+</phrase>
+
+<phrase>
+<original>rendering options</original>
+<translation>レンダリングオプション</translation>
+</phrase>
+
+<phrase>
+<original>level</original>
+<translation>レベル</translation>
+</phrase>
+
+<phrase>
+<original>maximum count</original>
+<translation>最大カウント</translation>
+</phrase>
+
+<phrase>
+<original>total pixels</original>
+<translation>総画素数</translation>
+</phrase>
+
+<phrase>
+<original>max count</original>
+<translation>最大カウント</translation>
+</phrase>
+
+<phrase>
+<original>Updating histogram</original>
+<translation>ヒストグラムの更新</translation>
+</phrase>
+
+<!-- Adjustments_Histogram_DisplayHistogram.frm contains 40 phrases. 29 were duplicates of existing phrases, so only 11 new phrases were written to file. -->
+
+<phrase>
+<original>radius</original>
+<translation>半径</translation>
+</phrase>
+
+<phrase>
+<original>target histogram</original>
+<translation>対象のヒストグラム</translation>
+</phrase>
+
+<phrase>
+<original>mode</original>
+<translation>モード</translation>
+</phrase>
+
+<phrase>
+<original>kernel shape</original>
+<translation>カーネルシェイプ</translation>
+</phrase>
+
+<phrase>
+<original>Equalizing image</original>
+<translation>画像の均等化</translation>
+</phrase>
+
+<phrase>
+<original>value</original>
+<translation>明度</translation>
+</phrase>
+
+<phrase>
+<original>global</original>
+<translation>全体</translation>
+</phrase>
+
+<phrase>
+<original>local</original>
+<translation>ローカル</translation>
+</phrase>
+
+<!-- Adjustments_Histogram_Equalize.frm contains 14 phrases. 6 were duplicates of existing phrases, so only 8 new phrases were written to file. -->
+
+<phrase>
+<original>set levels automatically</original>
+<translation>レベルを自動的に設定</translation>
+</phrase>
+
+<phrase>
+<original>output levels</original>
+<translation>出力レベル</translation>
+</phrase>
+
+<phrase>
+<original>input levels</original>
+<translation>入力レベル</translation>
+</phrase>
+
+<phrase>
+<original>When this button is active, you can set the shadow input level color by right-clicking a color in the preview window.</original>
+<translation>このボタンがアクティブの場合、プレビューウィンドウで色を右クリックして、シャドウ入力レベルの色を設定できます。</translation>
+</phrase>
+
+<phrase>
+<original>When this button is active, you can set the highlight input level color by right-clicking a color in the preview window.</original>
+<translation>このボタンがアクティブのときは、プレビュー ウィンドウで色を右クリックして、ハイライト入力レベルの色を設定できます。</translation>
+</phrase>
+
+<phrase>
+<original>Mapping new image levels</original>
+<translation>新規画像レベルのマッピング</translation>
+</phrase>
+
+<!-- Adjustments_Levels.frm contains 13 phrases. 7 were duplicates of existing phrases, so only 6 new phrases were written to file. -->
+
+<phrase>
+<original>foreground</original>
+<translation>フォアグラウンド</translation>
+</phrase>
+
+<phrase>
+<original>gamma</original>
+<translation>ガンマ</translation>
+</phrase>
+
+<phrase>
+<original>Removing haze from image</original>
+<translation>画像から霞を取り除く</translation>
+</phrase>
+
+<!-- Adjustments_Lighting_Dehaze.frm contains 7 phrases. 4 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>exposure compensation (stops)</original>
+<translation>露出補正</translation>
+</phrase>
+
+<phrase>
+<original>offset</original>
+<translation>オフセット</translation>
+</phrase>
+
+<phrase>
+<original>new exposure curve</original>
+<translation>新しい露出曲線</translation>
+</phrase>
+
+<phrase>
+<original>Adjusting image exposure</original>
+<translation>画像の露出を調整</translation>
+</phrase>
+
+<!-- Adjustments_Lighting_Exposure.frm contains 7 phrases. 3 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>keep all colors in sync</original>
+<translation>すべての色を同期させる</translation>
+</phrase>
+
+<phrase>
+<original>new gamma curve</original>
+<translation>新しいガンマ曲線</translation>
+</phrase>
+
+<phrase>
+<original>Adjusting gamma values</original>
+<translation>ガンマ値の調整</translation>
+</phrase>
+
+<!-- Adjustments_Lighting_Gamma.frm contains 8 phrases. 5 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>gradient type</original>
+<translation>グラデーション タイプ</translation>
+</phrase>
+
+<phrase>
+<original>midpoint</original>
+<translation>中点</translation>
+</phrase>
+
+<phrase>
+<original>Applying gradient map</original>
+<translation>グラデーション マップの適用</translation>
+</phrase>
+
+<!-- Adjustments_Map_Gradient.frm contains 10 phrases. 7 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>advice from the experts</original>
+<translation>エキスパートからのアドバイス</translation>
+</phrase>
+
+<phrase>
+<original>Explanation</original>
+<translation>説明</translation>
+</phrase>
+
+<phrase>
+<original>Converting monochrome image to grayscale</original>
+<translation>モノクロ画像をグレースケールに変換</translation>
+</phrase>
+
+<phrase>
+<original>Like all monochrome-to-grayscale tools, this tool will produce a blurry image.  You can use the Effects -> Sharpen -> Unsharp Masking tool to fix this.  (For best results, use an Unsharp Mask radius at least as large as this radius.)</original>
+<translation>他のモノクロからグレースケールへのツールと同様、このツールはぼやけた画像を生成します。  これを修正するには、 [エフェクト] -> [シャープ] -> [アンシャープ マスク] ツールを使用します。  (最良の結果を得るには、少なくともこの半径と同じ大きさのアンシャープマスク半径を使用してください)</translation>
+</phrase>
+
+<!-- Adjustments_Monochrome_MonoToGray.frm contains 8 phrases. 4 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>quality</original>
+<translation>品質</translation>
+</phrase>
+
+<phrase>
+<original>Generating HDR map for image</original>
+<translation>画像の HDR マップを生成</translation>
+</phrase>
+
+<!-- Adjustments_Photo_HDR.frm contains 5 phrases. 3 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>filter</original>
+<translation>フィルター</translation>
+</phrase>
+
+<phrase>
+<original>density</original>
+<translation>密度</translation>
+</phrase>
+
+<phrase>
+<original>Warming filter (%1)</original>
+<translation>ウォーム フィルター (%1)</translation>
+</phrase>
+
+<phrase>
+<original>Cooling filter (%1)</original>
+<translation>冷却フィルター (%1)</translation>
+</phrase>
+
+<phrase>
+<original>Red</original>
+<translation>レッド</translation>
+</phrase>
+
+<phrase>
+<original>Orange</original>
+<translation>オレンジ</translation>
+</phrase>
+
+<phrase>
+<original>Yellow</original>
+<translation>イエロー</translation>
+</phrase>
+
+<phrase>
+<original>Green</original>
+<translation>緑</translation>
+</phrase>
+
+<phrase>
+<original>Cyan</original>
+<translation>シアン</translation>
+</phrase>
+
+<phrase>
+<original>Blue</original>
+<translation>ブルー</translation>
+</phrase>
+
+<phrase>
+<original>Violet</original>
+<translation>バイオレット</translation>
+</phrase>
+
+<phrase>
+<original>Magenta</original>
+<translation>マゼンタ</translation>
+</phrase>
+
+<phrase>
+<original>Deep red</original>
+<translation>ディープレッド</translation>
+</phrase>
+
+<phrase>
+<original>Deep blue</original>
+<translation>ディープブルー</translation>
+</phrase>
+
+<phrase>
+<original>Deep emerald</original>
+<translation>ディープ エメラルド</translation>
+</phrase>
+
+<phrase>
+<original>Deep yellow</original>
+<translation>ディープイエロー</translation>
+</phrase>
+
+<phrase>
+<original>Custom</original>
+<translation>カスタム</translation>
+</phrase>
+
+<phrase>
+<original>Applying photo filter</original>
+<translation>写真フィルターの適用</translation>
+</phrase>
+
+<!-- Adjustments_Photo_PhotoFilters.frm contains 49 phrases. 31 were duplicates of existing phrases, so only 18 new phrases were written to file. -->
+
+<phrase>
+<original>balance</original>
+<translation>バランス</translation>
+</phrase>
+
+<phrase>
+<original>highlight color</original>
+<translation>ハイライトカラー</translation>
+</phrase>
+
+<phrase>
+<original>shadow color</original>
+<translation>シャドーカラー</translation>
+</phrase>
+
+<phrase>
+<original>toning strength</original>
+<translation>引き締め力</translation>
+</phrase>
+
+<phrase>
+<original>Split-toning image</original>
+<translation>スプリット トーン画像</translation>
+</phrase>
+
+<!-- Adjustments_Photo_SplitTone.frm contains 7 phrases. 2 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<phrase>
+<original>shadows</original>
+<translation>シャドウ</translation>
+</phrase>
+
+<phrase>
+<original>highlights</original>
+<translation>ハイライト</translation>
+</phrase>
+
+<phrase>
+<original>midtone contrast</original>
+<translation>中間調コントラスト</translation>
+</phrase>
+
+<phrase>
+<original>tonal width</original>
+<translation>トーン幅</translation>
+</phrase>
+
+<phrase>
+<original>Adjusting shadows, midtones, and highlights</original>
+<translation>シャドー、中間調、ハイライトの調整</translation>
+</phrase>
+
+<!-- Adjustments_ShadowAndHighlight.frm contains 17 phrases. 12 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<!-- Adjustments_WhiteBalance.frm contains 3 phrases.  All were duplicates of existing phrases, so no new phrases were written to file. -->
+
+<phrase>
+<original>Autosave data detected</original>
+<translation>自動保存のデータが検出</translation>
+</phrase>
+
+<phrase>
+<original>Attempt to recover</original>
+<translation>回復を試みる</translation>
+</phrase>
+
+<phrase>
+<original>Discard</original>
+<translation>破棄</translation>
+</phrase>
+
+<phrase>
+<original>Autosave data found.  Would you like to restore it?</original>
+<translation>自動保存のデータが見つかりました。  復元しますか?</translation>
+</phrase>
+
+<phrase>
+<original>A previous PhotoDemon session terminated unexpectedly.  Would you like to automatically recover the following autosaved images?</original>
+<translation>以前の PhotoDemon セッションが予期せず終了しました。  以下の自動保存された画像を回復しますか?</translation>
+</phrase>
+
+<phrase>
+<original>If you exit now, this autosave data will be lost forever.  Are you sure you want to exit?</original>
+<translation>いま終了すると、この自動保存データは永遠に失われます。  本当に終了しますか?</translation>
+</phrase>
+
+<phrase>
+<original>Warning: autosave data will be deleted</original>
+<translation>警告: 自動保存のデータは削除されます</translation>
+</phrase>
+
+<!-- Dialog_AutosaveFound.frm contains 10 phrases. 3 were duplicates of existing phrases, so only 7 new phrases were written to file. -->
+
+<phrase>
+<original>Color panel settings</original>
+<translation>カラー パネル設定</translation>
+</phrase>
+
+<phrase>
+<original>palettes in this file (%1)</original>
+<translation>このファイルのパレット (%1)</translation>
+</phrase>
+
+<phrase>
+<original>palette to use</original>
+<translation>使用するパレット</translation>
+</phrase>
+
+<phrase>
+<original>wheels + history</original>
+<translation>ホイール + 履歴</translation>
+</phrase>
+
+<phrase>
+<original>palette</original>
+<translation>パレット</translation>
+</phrase>
+
+<!-- Dialog_ColorPanel.frm contains 10 phrases. 5 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<phrase>
+<original>Change color</original>
+<translation>色を変える</translation>
+</phrase>
+
+<phrase>
+<original>HTML / CSS</original>
+<translation>HTML / CSS</translation>
+</phrase>
+
+<!-- Dialog_ColorSelector.frm contains 8 phrases. 6 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>Saved presets</original>
+<translation>保存されたプリセット</translation>
+</phrase>
+
+<phrase>
+<original>delete preset</original>
+<translation>削除プリセット</translation>
+</phrase>
+
+<phrase>
+<original>saved presets for this tool</original>
+<translation>このツールに保存されたプリセット</translation>
+</phrase>
+
+<phrase>
+<original>enter a name for this preset</original>
+<translation>このプリセットの名前を入力</translation>
+</phrase>
+
+<phrase>
+<original>(no saved presets)</original>
+<translation>(プリセットは保存されていません)</translation>
+</phrase>
+
+<phrase>
+<original>(enter name here)</original>
+<translation>(ここに名前を入力)</translation>
+</phrase>
+
+<phrase>
+<original>A preset with this name already exists.  Do you want to overwrite it?</original>
+<translation>この名前のプリセットはすでに存在します。  上書きしますか?</translation>
+</phrase>
+
+<phrase>
+<original>Overwrite existing preset</original>
+<translation>既存のプリセットを上書き</translation>
+</phrase>
+
+<phrase>
+<original>Please enter a name for this preset.</original>
+<translation>このプリセットの名前を入力してください。</translation>
+</phrase>
+
+<phrase>
+<original>Preset name required</original>
+<translation>プリセット名必須</translation>
+</phrase>
+
+<phrase>
+<original>add new preset</original>
+<translation>新しいプリセットを追加</translation>
+</phrase>
+
+<phrase>
+<original>edit existing presets</original>
+<translation>既存のプリセットを編集</translation>
+</phrase>
+
+<!-- Dialog_EditPreset.frm contains 25 phrases. 13 were duplicates of existing phrases, so only 12 new phrases were written to file. -->
+
+<phrase>
+<original>Fill settings</original>
+<translation>フィル設定</translation>
+</phrase>
+
+<phrase>
+<original>preview</original>
+<translation>プレビュー</translation>
+</phrase>
+
+<phrase>
+<original>colors</original>
+<translation>色</translation>
+</phrase>
+
+<phrase>
+<original>shape</original>
+<translation>形状</translation>
+</phrase>
+
+<phrase>
+<original>pattern</original>
+<translation>パターン</translation>
+</phrase>
+
+<phrase>
+<original>pattern color</original>
+<translation>パターン色</translation>
+</phrase>
+
+<phrase>
+<original>background color</original>
+<translation>背景色</translation>
+</phrase>
+
+<phrase>
+<original>solid</original>
+<translation>ソリッド</translation>
+</phrase>
+
+<phrase>
+<original>gradient</original>
+<translation>グラデーション</translation>
+</phrase>
+
+<phrase>
+<original>reflection</original>
+<translation>反射</translation>
+</phrase>
+
+<phrase>
+<original>rectangle</original>
+<translation>長方形</translation>
+</phrase>
+
+<!-- Dialog_FillSettings.frm contains 22 phrases. 11 were duplicates of existing phrases, so only 11 new phrases were written to file. -->
+
+<phrase>
+<original>Yes</original>
+<translation>はい</translation>
+</phrase>
+
+<phrase>
+<original>No</original>
+<translation>いいえ</translation>
+</phrase>
+
+<!-- Dialog_GenericRemember.frm contains 3 phrases.  One was a duplicate of an existing phrase, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>Please wait a moment</original>
+<translation>しばらくお待ちください</translation>
+</phrase>
+
+<phrase>
+<original>Please wait</original>
+<translation>お待ちください</translation>
+</phrase>
+
+<!-- Dialog_GenericWait.frm contains 2 phrases.  Both phrases were unique, so 2 new phrases were written to file. -->
+
+<phrase>
+<original>Gradient editor</original>
+<translation>グラデーションの編集</translation>
+</phrase>
+
+<phrase>
+<original>make node distances equal</original>
+<translation>ノードの距離を等しくする</translation>
+</phrase>
+
+<phrase>
+<original>additional options</original>
+<translation>追加のオプション</translation>
+</phrase>
+
+<phrase>
+<original>use gamma when blending</original>
+<translation>ブレンド時にガンマを使用</translation>
+</phrase>
+
+<phrase>
+<original>gradient name</original>
+<translation>グラデーション名</translation>
+</phrase>
+
+<phrase>
+<original>import gradient file</original>
+<translation>グラデーションのインポート</translation>
+</phrase>
+
+<phrase>
+<original>import / export</original>
+<translation>輸出入</translation>
+</phrase>
+
+<phrase>
+<original>export gradient file</original>
+<translation>グラデーションのエクスポート</translation>
+</phrase>
+
+<phrase>
+<original>save to gradient collection</original>
+<translation>グラデーション コレクションに保存</translation>
+</phrase>
+
+<phrase>
+<original>current node settings</original>
+<translation>現在のノード設定</translation>
+</phrase>
+
+<phrase>
+<original>position</original>
+<translation>位置</translation>
+</phrase>
+
+<phrase>
+<original>node editor</original>
+<translation>ノード エディタ</translation>
+</phrase>
+
+<phrase>
+<original>yes</original>
+<translation>はい</translation>
+</phrase>
+
+<phrase>
+<original>generate new pattern</original>
+<translation>新しいパターンを生成</translation>
+</phrase>
+
+<phrase>
+<original>start color and opacity</original>
+<translation>開始色と不透明度</translation>
+</phrase>
+
+<phrase>
+<original>end color and opacity</original>
+<translation>終了色と不透明度</translation>
+</phrase>
+
+<phrase>
+<original>noise density</original>
+<translation>ノイズ密度</translation>
+</phrase>
+
+<phrase>
+<original>vary hue</original>
+<translation>色相の変化</translation>
+</phrase>
+
+<phrase>
+<original>vary saturation</original>
+<translation>彩度の変化</translation>
+</phrase>
+
+<phrase>
+<original>vary luminance</original>
+<translation>明度の変化</translation>
+</phrase>
+
+<phrase>
+<original>vary alpha</original>
+<translation>アルファの変化</translation>
+</phrase>
+
+<phrase>
+<original>edit this gradient >></original>
+<translation>このグラデーションを編集 >></translation>
+</phrase>
+
+<phrase>
+<original>sort collection by</original>
+<translation>コレクションの並び替え</translation>
+</phrase>
+
+<phrase>
+<original>your collection</original>
+<translation>コレクション</translation>
+</phrase>
+
+<phrase>
+<original>A gradient with the name "%1" already exists in your collection.  Would you like to overwrite it?</original>
+<translation>名前 "%1" のグラデーションが既にコレクションに存在します。  上書きしますか?</translation>
+</phrase>
+
+<phrase>
+<original>Duplicate name</original>
+<translation>名前の重複</translation>
+</phrase>
+
+<phrase>
+<original>This gradient doesn't have a name.  Please give it a name before adding it to your collection.</original>
+<translation>このグラデーションには名前がありません。  コレクションに加える前に名前を付けてください。</translation>
+</phrase>
+
+<phrase>
+<original>Name required</original>
+<translation>名前必須</translation>
+</phrase>
+
+<phrase>
+<original>All supported gradients</original>
+<translation>すべてのグラデーションに対応</translation>
+</phrase>
+
+<phrase>
+<original>GIMP Gradient</original>
+<translation>GIMP グラデーション</translation>
+</phrase>
+
+<phrase>
+<original>SVG Gradient</original>
+<translation>Svgグラデーション</translation>
+</phrase>
+
+<phrase>
+<original>Import gradient</original>
+<translation>グラデーションのインポート</translation>
+</phrase>
+
+<phrase>
+<original>Unfortunately, the gradient file "%1" doesn't appear to be a valid gradient file.</original>
+<translation>残念ながら、グラデーション ファイル"%1 "は有効なグラデーション ファイルではないようです。</translation>
+</phrase>
+
+<phrase>
+<original>Invalid gradient</original>
+<translation>無効なグラデーション</translation>
+</phrase>
+
+<phrase>
+<original>New gradient</original>
+<translation>新しいグラデーション</translation>
+</phrase>
+
+<phrase>
+<original>Export gradient</original>
+<translation>グラデーションのエクスポート</translation>
+</phrase>
+
+<phrase>
+<original>Left-click to add new nodes or edit existing nodes.  Right-click a node to remove it.</original>
+<translation>新しいノードを追加したり、既存のノードを編集するには、左クリックします。  ノードを削除するには、ノードを右クリックします。</translation>
+</phrase>
+
+<phrase>
+<original>gradient collection</original>
+<translation>グラデーション コレクション</translation>
+</phrase>
+
+<phrase>
+<original>make your own</original>
+<translation>自分で作る</translation>
+</phrase>
+
+<phrase>
+<original>noise gradients</original>
+<translation>ノイズ グラデーション</translation>
+</phrase>
+
+<phrase>
+<original>filename</original>
+<translation>ファイル名</translation>
+</phrase>
+
+<phrase>
+<original>complexity</original>
+<translation>複雑さ</translation>
+</phrase>
+
+<phrase>
+<original>Your gradient collection is stored in the "%1" folder</original>
+<translation>グラデーション コレクションは "%1" フォルダに保存されます。</translation>
+</phrase>
+
+<phrase>
+<original>When a gradient contains colors with wildly different luminance values, gamma correction may improve its appearance.</original>
+<translation>グラデーションに輝度値の大きく異なる色が含まれる場合、ガンマ補正をすると見栄えが良くなることがあります。</translation>
+</phrase>
+
+<phrase>
+<original>Use this setting to automatically calculate equal positioning for all gradient nodes.</original>
+<translation>この設定を使用すると、すべてのグラデーションノードの等しい位置が自動的に計算されます。</translation>
+</phrase>
+
+<phrase>
+<original>Foreground to black</original>
+<translation>前景を黒に</translation>
+</phrase>
+
+<phrase>
+<original>Foreground to white</original>
+<translation>前景を白に</translation>
+</phrase>
+
+<phrase>
+<original>Foreground to transparent</original>
+<translation>前景を透明に</translation>
+</phrase>
+
+<phrase>
+<original>node settings</original>
+<translation>ノード設定</translation>
+</phrase>
+
+<phrase>
+<original>please select a node</original>
+<translation>ノードを選択してください</translation>
+</phrase>
+
+<!-- Dialog_GradientEditor.frm contains 79 phrases. 29 were duplicates of existing phrases, so only 50 new phrases were written to file. -->
+
+<phrase>
+<original>I understand the risks of running PhotoDemon in the IDE</original>
+<translation>IDEでPhotoDemonを実行するリスクを理解しています。</translation>
+</phrase>
+
+<phrase>
+<original>Do not display this warning again</original>
+<translation>この警告を再度表示しない</translation>
+</phrase>
+
+<!-- Dialog_IDEWarning.frm contains 2 phrases.  Both phrases were unique, so 2 new phrases were written to file. -->
+
+<!-- Dialog_MsgBox.frm contains 16 phrases.  All were duplicates of existing phrases, so no new phrases were written to file. -->
+
+<phrase>
+<original>Outline settings</original>
+<translation>アウトライン設定</translation>
+</phrase>
+
+<phrase>
+<original>corner shape</original>
+<translation>コーナー形状</translation>
+</phrase>
+
+<phrase>
+<original>line cap shape</original>
+<translation>線の端の形状</translation>
+</phrase>
+
+<phrase>
+<original>miter limit</original>
+<translation>斜め継ぎ限界</translation>
+</phrase>
+
+<phrase>
+<original>dashes</original>
+<translation>ダッシュ</translation>
+</phrase>
+
+<phrase>
+<original>dots</original>
+<translation>ドット</translation>
+</phrase>
+
+<phrase>
+<original>dash + dot</original>
+<translation>ダッシュ + ドット</translation>
+</phrase>
+
+<phrase>
+<original>dash + dot + dot</original>
+<translation>ダッシュ + ドット + ドット</translation>
+</phrase>
+
+<phrase>
+<original>flat</original>
+<translation>フラット</translation>
+</phrase>
+
+<phrase>
+<original>round</original>
+<translation>端を中心にして丸め</translation>
+</phrase>
+
+<phrase>
+<original>miter</original>
+<translation>斜め継ぎ</translation>
+</phrase>
+
+<phrase>
+<original>bevel</original>
+<translation>ベベル</translation>
+</phrase>
+
+<!-- Dialog_OutlineSettings.frm contains 20 phrases. 8 were duplicates of existing phrases, so only 12 new phrases were written to file. -->
+
+<phrase>
+<original>Waiting for user to specify import options</original>
+<translation>ユーザーがインポート オプションを指定するのを待っています</translation>
+</phrase>
+
+<phrase>
+<original>%1 options</original>
+<translation>%1 オプション</translation>
+</phrase>
+
+<!-- Dialog_SVGImport.frm contains 3 phrases.  One was a duplicate of an existing phrase, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>HDR image identified</original>
+<translation>HDR 画像の識別</translation>
+</phrase>
+
+<phrase>
+<original>in the future, automatically apply these settings</original>
+<translation>将来、これらの設定を自動的に適用する</translation>
+</phrase>
+
+<phrase>
+<original>tone-mapping operator</original>
+<translation>トーンマッピング演算子</translation>
+</phrase>
+
+<phrase>
+<original>exposure</original>
+<translation>露出</translation>
+</phrase>
+
+<phrase>
+<original>white point</original>
+<translation>ホワイトポイント</translation>
+</phrase>
+
+<phrase>
+<original>normalize</original>
+<translation>ノーマライズ</translation>
+</phrase>
+
+<phrase>
+<original>adaptation</original>
+<translation>適応</translation>
+</phrase>
+
+<phrase>
+<original>color correction</original>
+<translation>色補正</translation>
+</phrase>
+
+<phrase>
+<original>This image contains more than 16 million colors.  Before it can be displayed on your screen, it must be converted to a simpler format.  This process is called tone mapping.</original>
+<translation>この画像には1600万色以上の色が含まれています。  画面に表示する前に、よりシンプルなフォーマットに変換する必要があります。  この処理をトーンマッピングと呼びます。</translation>
+</phrase>
+
+<phrase>
+<original>Waiting for tone mapping instructions</original>
+<translation>トーンマッピングの指示待ち</translation>
+</phrase>
+
+<phrase>
+<original>Proceeding with tone mapping</original>
+<translation>トーンマッピングを進める</translation>
+</phrase>
+
+<phrase>
+<original>Linear</original>
+<translation>線形</translation>
+</phrase>
+
+<phrase>
+<original>Filmic</original>
+<translation>フィルミック</translation>
+</phrase>
+
+<phrase>
+<original>visible spectrum</original>
+<translation>可視スペクトル</translation>
+</phrase>
+
+<phrase>
+<original>full spectrum</original>
+<translation>フルスペクトル</translation>
+</phrase>
+
+<!-- Dialog_ToneMapping.frm contains 26 phrases. 11 were duplicates of existing phrases, so only 15 new phrases were written to file. -->
+
+<phrase>
+<original>Theme and language</original>
+<translation>テーマと言語</translation>
+</phrase>
+
+<phrase>
+<original>icons</original>
+<translation>アイコン</translation>
+</phrase>
+
+<phrase>
+<original>interface accent color</original>
+<translation>インターフェイスのアクセント カラー</translation>
+</phrase>
+
+<phrase>
+<original>interface theme</original>
+<translation>インターフェイスのテーマ</translation>
+</phrase>
+
+<phrase>
+<original>language</original>
+<translation>言語</translation>
+</phrase>
+
+<phrase>
+<original>dark</original>
+<translation>ダーク</translation>
+</phrase>
+
+<phrase>
+<original>light</original>
+<translation>ライト</translation>
+</phrase>
+
+<phrase>
+<original>brown</original>
+<translation>茶</translation>
+</phrase>
+
+<phrase>
+<original>orange</original>
+<translation>オレンジ</translation>
+</phrase>
+
+<phrase>
+<original>pink</original>
+<translation>ピンク</translation>
+</phrase>
+
+<phrase>
+<original>purple</original>
+<translation>紫</translation>
+</phrase>
+
+<phrase>
+<original>teal</original>
+<translation>青緑</translation>
+</phrase>
+
+<phrase>
+<original>default</original>
+<translation>既定</translation>
+</phrase>
+
+<phrase>
+<original>monochromatic</original>
+<translation>モノクロ</translation>
+</phrase>
+
+<phrase>
+<original>Translation by %1</original>
+<translation>%1 が翻訳</translation>
+</phrase>
+
+<phrase>
+<original>You can change language and theme settings at any time from the Tools menu.</original>
+<translation>言語とテーマの設定は、ツール メニューからいつでも変更できます。</translation>
+</phrase>
+
+<phrase>
+<original>Additional interface customizations are available in the Window menu.</original>
+<translation>その他のインターフェイスのカスタマイズはウインドウ メニューで可能です。</translation>
+</phrase>
+
+<!-- Dialog_UITheme.frm contains 23 phrases. 6 were duplicates of existing phrases, so only 17 new phrases were written to file. -->
+
+<phrase>
+<original>Unsaved changes</original>
+<translation>未保存の変更</translation>
+</phrase>
+
+<phrase>
+<original>images with unsaved changes</original>
+<translation>未保存の変更のある画像</translation>
+</phrase>
+
+<phrase>
+<original>Save the image before closing it</original>
+<translation>画像を閉じる前に保存</translation>
+</phrase>
+
+<phrase>
+<original>Repeat this action for all unsaved images (%1 in total)</original>
+<translation>保存されていないすべての画像 (合計 %1)に対してこの操作を繰り返します。</translation>
+</phrase>
+
+<phrase>
+<original>Do not save the image (discard all changes)</original>
+<translation>画像を保存しない (すべての変更は失われます)</translation>
+</phrase>
+
+<phrase>
+<original>Cancel, and return to editing</original>
+<translation>キャンセルし、編集に戻る</translation>
+</phrase>
+
+<phrase>
+<original>NOTE: if you click 'Save', PhotoDemon will save this image using its current file name.
+
+If you want to save it with a different file name, please select 'Cancel', then use the File -> Save As menu item.</original>
+<translation>注意: 「保存」をクリックすると、PhotoDemon はこの画像を現在のファイル名で保存します。
+
+異なるファイル名で保存したい場合、「キャンセル」を選択し、ファイル -> 名前を付けて保存メニュー項目を使用してください。</translation>
+</phrase>
+
+<phrase>
+<original>Because this image has not been saved before, you will be prompted to provide a file name for it.</original>
+<translation>この画像は以前に保存されていないため、ファイル名を入力するよう求められます。</translation>
+</phrase>
+
+<phrase>
+<original>If you do not save this image, any changes you have made will be permanently lost.</original>
+<translation>この画像を保存しないと、加えた変更は永久に失われます。</translation>
+</phrase>
+
+<phrase>
+<original>Canceling will return you to the main PhotoDemon window.</original>
+<translation>キャンセルすると、PhotoDemon のメインウィンドウに戻ります。</translation>
+</phrase>
+
+<phrase>
+<original>This image</original>
+<translation>この画像</translation>
+</phrase>
+
+<phrase>
+<original>%1 has unsaved changes.  What would you like to do?</original>
+<translation>%1 は未保存の変更があります。 どうしますか?</translation>
+</phrase>
+
+<phrase>
+<original>unnamed image %1</original>
+<translation>無題の画像 %1</translation>
+</phrase>
+
+<phrase>
+<original>Repeat this action for both unsaved images</original>
+<translation>保存されていないすべての画像にこの操作を繰り返す</translation>
+</phrase>
+
+<!-- Dialog_UnsavedChanges.frm contains 20 phrases. 6 were duplicates of existing phrases, so only 14 new phrases were written to file. -->
+
+<phrase>
+<original>Update ready</original>
+<translation>更新の準備ができました</translation>
+</phrase>
+
+<phrase>
+<original>Restart PhotoDemon</original>
+<translation>PhotoDemon を再起動</translation>
+</phrase>
+
+<phrase>
+<original>in the future, do not notify me of updates</original>
+<translation>今後、アップデートの通知はしない</translation>
+</phrase>
+
+<phrase>
+<original>Keep working</original>
+<translation>働き続ける</translation>
+</phrase>
+
+<phrase>
+<original>Learn more about the new features in %1</original>
+<translation>%1 の新機能の詳細をご覧ください。</translation>
+</phrase>
+
+<phrase>
+<original>(Sorry, but automatic restarts don't work inside the IDE.)</original>
+<translation>(申し訳ありませんが、自動再起動は IDE 内部では機能しません)</translation>
+</phrase>
+
+<phrase>
+<original>A new version of PhotoDemon is available.  Restart the program to complete the update process.</original>
+<translation>PhotoDemon の新しいバージョンが利用可能です。  アップデート処理を完了するには、プログラムを再起動してください。</translation>
+</phrase>
+
+<phrase>
+<original>Restart now to access to the latest version of the program.</original>
+<translation>プログラムの最新バージョンにアクセスするには、今すぐ再起動してください。</translation>
+</phrase>
+
+<phrase>
+<original>Apply update now</original>
+<translation>今すぐアップデートを申し込む</translation>
+</phrase>
+
+<phrase>
+<original>If you're in the middle of something, feel free to keep working.  The update process will automatically complete whenever you next use the program.</original>
+<translation>何か作業をしている最中でも、遠慮なく作業を続けてください。  アップデートの処理は、次にプログラムを使用するときに自動的に完了します。</translation>
+</phrase>
+
+<phrase>
+<original>Apply update later</original>
+<translation>あとでアップデートを適用</translation>
+</phrase>
+
+<!-- Dialog_UpdateAvailable.frm contains 14 phrases. 3 were duplicates of existing phrases, so only 11 new phrases were written to file. -->
+
+<phrase>
+<original>use merged image</original>
+<translation>結合された画像を使用</translation>
+</phrase>
+
+<phrase>
+<original>available formats</original>
+<translation>利用可能なフォーマット</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon Image</original>
+<translation>PhotoDemon 画像</translation>
+</phrase>
+
+<phrase>
+<original>Bitmap</original>
+<translation>ビットマップ</translation>
+</phrase>
+
+<!-- Edit_Clipboard.frm contains 10 phrases. 6 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>above</original>
+<translation>上</translation>
+</phrase>
+
+<phrase>
+<original>sample from</original>
+<translation>サンプル</translation>
+</phrase>
+
+<phrase>
+<original>fill order</original>
+<translation>塗りつぶす方向</translation>
+</phrase>
+
+<phrase>
+<original>patch test size</original>
+<translation>パッチ テスト サイズ</translation>
+</phrase>
+
+<phrase>
+<original>random patch candidates</original>
+<translation>ランダム パッチの候補</translation>
+</phrase>
+
+<phrase>
+<original>refinement (percent)</original>
+<translation>洗練度 (%)</translation>
+</phrase>
+
+<phrase>
+<original>patch perfection threshold</original>
+<translation>パッチ パーフェクション しきい値</translation>
+</phrase>
+
+<phrase>
+<original>sample radius</original>
+<translation>サンプルの半径</translation>
+</phrase>
+
+<phrase>
+<original>left</original>
+<translation>左</translation>
+</phrase>
+
+<phrase>
+<original>right</original>
+<translation>右</translation>
+</phrase>
+
+<phrase>
+<original>below</original>
+<translation>下</translation>
+</phrase>
+
+<phrase>
+<original>outside-in</original>
+<translation>外から内へ</translation>
+</phrase>
+
+<phrase>
+<original>inside-out</original>
+<translation>内から外へ</translation>
+</phrase>
+
+<!-- Edit_ContentAwareFill.frm contains 16 phrases. 3 were duplicates of existing phrases, so only 13 new phrases were written to file. -->
+
+<phrase>
+<original>Fading previous action (%1)</original>
+<translation>前のアクションのフェード (%1)</translation>
+</phrase>
+
+<phrase>
+<original>Fade complete.</original>
+<translation>フェードを完了しました。</translation>
+</phrase>
+
+<!-- Edit_Fade.frm contains 6 phrases. 4 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>brush</original>
+<translation>ブラシ</translation>
+</phrase>
+
+<phrase>
+<original>layer size</original>
+<translation>レイヤーサイズ</translation>
+</phrase>
+
+<phrase>
+<original>Applying fill</original>
+<translation>塗りつぶし</translation>
+</phrase>
+
+<phrase>
+<original>do not change</original>
+<translation>変更しない</translation>
+</phrase>
+
+<phrase>
+<original>use selection size</original>
+<translation>使用選択サイズ</translation>
+</phrase>
+
+<phrase>
+<original>use combined size (union)</original>
+<translation>複合サイズを使用 (ユニオン)</translation>
+</phrase>
+
+<!-- Edit_Fill.frm contains 11 phrases. 5 were duplicates of existing phrases, so only 6 new phrases were written to file. -->
+
+<phrase>
+<original>pen</original>
+<translation>ペン</translation>
+</phrase>
+
+<phrase>
+<original>Stroking outline</original>
+<translation>輪郭をなでる</translation>
+</phrase>
+
+<phrase>
+<original>expand to fit stroke (if necessary)</original>
+<translation>ストロークに合わせて拡大 (必要な場合)</translation>
+</phrase>
+
+<!-- Edit_Stroke.frm contains 10 phrases. 7 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>* current image state</original>
+<translation>* 現在の画像の状態</translation>
+</phrase>
+
+<phrase>
+<original>available image states</original>
+<translation>使用可能な画像状態</translation>
+</phrase>
+
+<phrase>
+<original>layer: %1</original>
+<translation>レイヤ: %1</translation>
+</phrase>
+
+<phrase>
+<original>selection shape shown</original>
+<translation>選択形状を表示</translation>
+</phrase>
+
+<!-- Edit_UndoHistory.frm contains 8 phrases. 4 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>scan for new plugins</original>
+<translation>新しいプラグインを探す</translation>
+</phrase>
+
+<phrase>
+<original>about this plugin</original>
+<translation>このプラグインについて</translation>
+</phrase>
+
+<phrase>
+<original>available plugins</original>
+<translation>利用可能なプラグイン</translation>
+</phrase>
+
+<phrase>
+<original>add folder</original>
+<translation>フォルダを追加</translation>
+</phrase>
+
+<phrase>
+<original>default plugin folder</original>
+<translation>既定のプラグイン フォルダ</translation>
+</phrase>
+
+<phrase>
+<original>additional folders</original>
+<translation>追加のフォルダ</translation>
+</phrase>
+
+<phrase>
+<original>remove folder</original>
+<translation>フォルダを除去</translation>
+</phrase>
+
+<phrase>
+<original>Waiting for plugin</original>
+<translation>プラグイン待ち</translation>
+</phrase>
+
+<phrase>
+<original>Plugin canceled.</original>
+<translation>プラグインがキャンセルされました。</translation>
+</phrase>
+
+<phrase>
+<original>plugins</original>
+<translation>プラグイン</translation>
+</phrase>
+
+<phrase>
+<original>settings</original>
+<translation>設定</translation>
+</phrase>
+
+<phrase>
+<original>loading plugin collection</original>
+<translation>プラグインコレクションの読み込み</translation>
+</phrase>
+
+<phrase>
+<original>No plugins found.</original>
+<translation>プラグインが見つかりません。</translation>
+</phrase>
+
+<phrase>
+<original>Photoshop (8bf) plugins are files with an "8bf" extension.  These plugins provide new image effects.  Thousands of 8bf plugins are available online.</original>
+<translation>Photoshop (8Bf) プラグインは、拡張子が "8bf" のファイルです。  これらのプラグインは、新規画像効果を提供します。  何千もの 8bf プラグインがオンラインにあります。</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon does not ship with 8bf plugins, but if you find plugins online, you can download them and add them to PhotoDemon.  (PhotoDemon supports most 32-bit 8bf plugins.  64-bit plugins are not supported.)</original>
+<translation>PhotoDemon は 8bf プラグインを同梱しませんが、オンラインでプラグインを見つけた場合、それらをダウンロードして PhotoDemon に追加できます。  (PhotoDemon は、ほとんどの 32 ビット 8bf プラグインをサポートしています。  64 ビット プラグインはサポートされていません)</translation>
+</phrase>
+
+<phrase>
+<original>After downloading one or more 8bf files, use the settings button (above) to tell PhotoDemon where to find them.  PhotoDemon will then add them to your Effects collection.</original>
+<translation>1 つまたは複数の 8bf ファイルをダウンロードしたあと、設定ボタン (上記) を使用して、PhotoDemon にそれらの場所を指定します。  PhotoDemon はそれらをエフェクト コレクションに追加します。</translation>
+</phrase>
+
+<!-- Effects_8bf.frm contains 25 phrases. 9 were duplicates of existing phrases, so only 16 new phrases were written to file. -->
+
+<phrase>
+<original>after processing, delete this layer</original>
+<translation>処理後、このレイヤーを削除</translation>
+</phrase>
+
+<phrase>
+<original>background layer</original>
+<translation>背景レイヤー</translation>
+</phrase>
+
+<phrase>
+<original>first frame for effect</original>
+<translation>エフェクトの最初のフレーム</translation>
+</phrase>
+
+<phrase>
+<original>last frame for effect</original>
+<translation>エフェクトの最後のフレーム</translation>
+</phrase>
+
+<phrase>
+<original>Applying background</original>
+<translation>背景の適用</translation>
+</phrase>
+
+<phrase>
+<original>Applying foreground</original>
+<translation>前景の適用</translation>
+</phrase>
+
+<phrase>
+<original>waiting</original>
+<translation>待機中</translation>
+</phrase>
+
+<phrase>
+<original>foreground layer</original>
+<translation>前景レイヤー</translation>
+</phrase>
+
+<!-- Effects_Animation_Background.frm contains 23 phrases. 15 were duplicates of existing phrases, so only 8 new phrases were written to file. -->
+
+<phrase>
+<original>speed modifier</original>
+<translation>速度の指定</translation>
+</phrase>
+
+<!-- Effects_Animation_Speed.frm contains 12 phrases. 11 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>tip radius</original>
+<translation>先端半径</translation>
+</phrase>
+
+<phrase>
+<original>pressure</original>
+<translation>圧力</translation>
+</phrase>
+
+<phrase>
+<original>Sketching image with pencils</original>
+<translation>鉛筆で画像をスケッチ</translation>
+</phrase>
+
+<phrase>
+<original>Luminous</original>
+<translation>ルミナス</translation>
+</phrase>
+
+<phrase>
+<original>Pastel</original>
+<translation>パステル</translation>
+</phrase>
+
+<phrase>
+<original>Graphite</original>
+<translation>グラファイト</translation>
+</phrase>
+
+<!-- Effects_Artistic_ColoredPencil.frm contains 10 phrases. 4 were duplicates of existing phrases, so only 6 new phrases were written to file. -->
+
+<phrase>
+<original>brush smoothing</original>
+<translation>ブラシのスムージング</translation>
+</phrase>
+
+<phrase>
+<original>ink</original>
+<translation>インク</translation>
+</phrase>
+
+<phrase>
+<original>brush size</original>
+<translation>ブラシ サイズ</translation>
+</phrase>
+
+<phrase>
+<original>Animating image (stage %1 of %2)</original>
+<translation>画像をアニメートしています (ステージ %1 / %2)</translation>
+</phrase>
+
+<phrase>
+<original>Animating image</original>
+<translation>アニメーション画像</translation>
+</phrase>
+
+<phrase>
+<original>low</original>
+<translation>低い</translation>
+</phrase>
+
+<phrase>
+<original>medium</original>
+<translation>中間</translation>
+</phrase>
+
+<phrase>
+<original>high</original>
+<translation>高い</translation>
+</phrase>
+
+<!-- Effects_Artistic_ComicBook.frm contains 14 phrases. 6 were duplicates of existing phrases, so only 8 new phrases were written to file. -->
+
+<phrase>
+<original>if pixels lie outside the image</original>
+<translation>ピクセルが画像の外側にある場合</translation>
+</phrase>
+
+<phrase>
+<original>scale</original>
+<translation>スケール</translation>
+</phrase>
+
+<phrase>
+<original>turbulence</original>
+<translation>不穏</translation>
+</phrase>
+
+<phrase>
+<original>random seed</original>
+<translation>ランダム シード</translation>
+</phrase>
+
+<phrase>
+<original>Projecting image through simulated glass</original>
+<translation>模擬ガラスを通して映像を投影</translation>
+</phrase>
+
+<!-- Effects_Artistic_FiguredGlass.frm contains 8 phrases. 3 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<phrase>
+<original>shadow cut-off</original>
+<translation>シャドーカット</translation>
+</phrase>
+
+<phrase>
+<original>contrast boost</original>
+<translation>コントラスト ブースト</translation>
+</phrase>
+
+<phrase>
+<original>highlight cut-off</original>
+<translation>ハイライト カット オフ</translation>
+</phrase>
+
+<phrase>
+<original>contrast midpoint</original>
+<translation>コントラスト中点</translation>
+</phrase>
+
+<phrase>
+<original>film grain</original>
+<translation>フィルム グレイン</translation>
+</phrase>
+
+<phrase>
+<original>Asking Sam Spade for help</original>
+<translation>サム・スペードに助けを求める</translation>
+</phrase>
+
+<!-- Effects_Artistic_FilmNoir.frm contains 8 phrases. 2 were duplicates of existing phrases, so only 6 new phrases were written to file. -->
+
+<phrase>
+<original>curvature</original>
+<translation>曲率</translation>
+</phrase>
+
+<phrase>
+<original>Generating glass tiles</original>
+<translation>ガラスタイルの製造</translation>
+</phrase>
+
+<!-- Effects_Artistic_GlassTiles.frm contains 9 phrases. 7 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>number of mirrors</original>
+<translation>ミラー数</translation>
+</phrase>
+
+<phrase>
+<original>primary angle</original>
+<translation>プライマリーアングル</translation>
+</phrase>
+
+<phrase>
+<original>you can also set a center position by clicking the preview window</original>
+<translation>プレビュー ウィンドウをクリックして中心位置を設定することもできます。</translation>
+</phrase>
+
+<phrase>
+<original>center position (x, y)</original>
+<translation>中心位置 (x、y)</translation>
+</phrase>
+
+<phrase>
+<original>secondary angle</original>
+<translation>副角度</translation>
+</phrase>
+
+<phrase>
+<original>radius (percentage)</original>
+<translation>半径</translation>
+</phrase>
+
+<phrase>
+<original>render emphasis</original>
+<translation>強調レンダー</translation>
+</phrase>
+
+<phrase>
+<original>Peering at image through imaginary kaleidoscope</original>
+<translation>想像上の万華鏡を通して画像を覗き込む</translation>
+</phrase>
+
+<phrase>
+<original>speed</original>
+<translation>スピード</translation>
+</phrase>
+
+<!-- Effects_Artistic_Kaleidoscope.frm contains 17 phrases. 8 were duplicates of existing phrases, so only 9 new phrases were written to file. -->
+
+<phrase>
+<original>horizontal strength</original>
+<translation>水平強度</translation>
+</phrase>
+
+<phrase>
+<original>vertical strength</original>
+<translation>垂直力</translation>
+</phrase>
+
+<phrase>
+<original>Applying modern art techniques</original>
+<translation>現代美術のテクニックを応用</translation>
+</phrase>
+
+<!-- Effects_Artistic_ModernArt.frm contains 6 phrases. 3 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>detail</original>
+<translation>詳細</translation>
+</phrase>
+
+<phrase>
+<original>Repainting image with oils</original>
+<translation>油絵の具で画像を塗り替える</translation>
+</phrase>
+
+<!-- Effects_Artistic_OilPainting.frm contains 5 phrases. 3 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>smoothness</original>
+<translation>滑らかさ</translation>
+</phrase>
+
+<phrase>
+<original>thickness</original>
+<translation>厚さ</translation>
+</phrase>
+
+<phrase>
+<original>light angle</original>
+<translation>ライトアングル</translation>
+</phrase>
+
+<phrase>
+<original>light intensity</original>
+<translation>光度</translation>
+</phrase>
+
+<phrase>
+<original>Wrapping image in plastic</original>
+<translation>画像をビニールで包む</translation>
+</phrase>
+
+<!-- Effects_Artistic_PlasticWrap.frm contains 8 phrases. 3 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<phrase>
+<original>adaptive coloring</original>
+<translation>適応カラーリング</translation>
+</phrase>
+
+<phrase>
+<original>possible red values</original>
+<translation>可能な赤の値</translation>
+</phrase>
+
+<phrase>
+<original>possible green values</original>
+<translation>可能な緑の値</translation>
+</phrase>
+
+<phrase>
+<original>possible blue values</original>
+<translation>可能な青の値</translation>
+</phrase>
+
+<phrase>
+<original>Posterizing image</original>
+<translation>ポスター画像</translation>
+</phrase>
+
+<!-- Effects_Artistic_Posterize.frm contains 11 phrases. 6 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<phrase>
+<original>Carving image relief</original>
+<translation>彫像レリーフ</translation>
+</phrase>
+
+<!-- Effects_Artistic_Relief.frm contains 6 phrases. 5 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>cell size</original>
+<translation>セルサイズ</translation>
+</phrase>
+
+<phrase>
+<original>shading quality</original>
+<translation>シェーディングのクオリティ</translation>
+</phrase>
+
+<phrase>
+<original>distance method</original>
+<translation>距離法</translation>
+</phrase>
+
+<phrase>
+<original>edge thickness</original>
+<translation>縁の厚さ</translation>
+</phrase>
+
+<phrase>
+<original>color sampling</original>
+<translation>カラーサンプリング</translation>
+</phrase>
+
+<phrase>
+<original>edge color and opacity</original>
+<translation>エッジの色と不透明度</translation>
+</phrase>
+
+<phrase>
+<original>Carving image from stained glass</original>
+<translation>ステンドグラスから画像を彫る</translation>
+</phrase>
+
+<phrase>
+<original>accurate</original>
+<translation>正確</translation>
+</phrase>
+
+<phrase>
+<original>fast</original>
+<translation>速い</translation>
+</phrase>
+
+<phrase>
+<original>Cartesian (traditional)</original>
+<translation>カルテジアン (伝統的)</translation>
+</phrase>
+
+<phrase>
+<original>Manhattan (walking)</original>
+<translation>マンハッタン (徒歩)</translation>
+</phrase>
+
+<phrase>
+<original>Chebyshev (chessboard)</original>
+<translation>チェビシェフ</translation>
+</phrase>
+
+<!-- Effects_Artistic_StainedGlass.frm contains 22 phrases. 10 were duplicates of existing phrases, so only 12 new phrases were written to file. -->
+
+<phrase>
+<original>box width</original>
+<translation>ボックス幅</translation>
+</phrase>
+
+<phrase>
+<original>keep both dimensions in sync</original>
+<translation>両次元を同期させる</translation>
+</phrase>
+
+<phrase>
+<original>box height</original>
+<translation>ボックスの高さ</translation>
+</phrase>
+
+<phrase>
+<original>Applying box blur to image</original>
+<translation>画像にボックスぼかしを適用</translation>
+</phrase>
+
+<!-- Effects_Blur_BoxBlur.frm contains 6 phrases. 2 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>iterations</original>
+<translation>反復</translation>
+</phrase>
+
+<phrase>
+<original>algorithms</original>
+<translation>アルゴリズム</translation>
+</phrase>
+
+<phrase>
+<original>Applying gaussian blur</original>
+<translation>ガウスぼかしの適用</translation>
+</phrase>
+
+<phrase>
+<original>radius (Photoshop equivalent)</original>
+<translation>半径 (Photoshopと同等)</translation>
+</phrase>
+
+<phrase>
+<original>standard deviation (%1)</original>
+<translation>標準偏差 (%1)</translation>
+</phrase>
+
+<phrase>
+<original>precise</original>
+<translation>精密</translation>
+</phrase>
+
+<phrase>
+<original>iterative box blur</original>
+<translation>反復ボックスぼかし</translation>
+</phrase>
+
+<phrase>
+<original>anisotropic diffusion (Alvarez-Mazorra)</original>
+<translation>異方性拡散 (アルバレス・マゾーラ)</translation>
+</phrase>
+
+<!-- Effects_Blur_GaussianBlur.frm contains 15 phrases. 7 were duplicates of existing phrases, so only 8 new phrases were written to file. -->
+
+<phrase>
+<original>Applying Kuwahara filter</original>
+<translation>桑原フィルターの適用</translation>
+</phrase>
+
+<!-- Effects_Blur_Kuwahara.frm contains 4 phrases. 3 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>blur symmetrically</original>
+<translation>左右対称にぼかす</translation>
+</phrase>
+
+<phrase>
+<original>distance</original>
+<translation>距離</translation>
+</phrase>
+
+<phrase>
+<original>Applying motion blur</original>
+<translation>モーションブラーの適用</translation>
+</phrase>
+
+<phrase>
+<original>gaussian</original>
+<translation>ガウシアン</translation>
+</phrase>
+
+<!-- Effects_Blur_MotionBlur.frm contains 9 phrases. 5 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>Applying radial blur</original>
+<translation>放射状にぼかす</translation>
+</phrase>
+
+<phrase>
+<original>accuracy</original>
+<translation>精度</translation>
+</phrase>
+
+<!-- Effects_Blur_RadialBlur.frm contains 8 phrases. 6 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>Generating symmetric pixel pairs</original>
+<translation>対称ピクセルペアの生成</translation>
+</phrase>
+
+<!-- Effects_Blur_SNN.frm contains 5 phrases. 4 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>Applying surface blur</original>
+<translation>サーフェスブラーの適用</translation>
+</phrase>
+
+<!-- Effects_Blur_SurfaceBlur.frm contains 5 phrases. 4 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>Applying zoom blur</original>
+<translation>ズームブラーの適用</translation>
+</phrase>
+
+<!-- Effects_Blur_ZoomBlur.frm contains 6 phrases. 5 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>automatically normalize divisor and offset</original>
+<translation>除数とオフセットを自動的に正規化</translation>
+</phrase>
+
+<phrase>
+<original>divisor</original>
+<translation>除数</translation>
+</phrase>
+
+<phrase>
+<original>convolution matrix</original>
+<translation>畳み込み行列</translation>
+</phrase>
+
+<!-- Effects_CustomFilter.frm contains 8 phrases. 5 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>Projecting image through simulated lens</original>
+<translation>模擬レンズを通して映像を投影</translation>
+</phrase>
+
+<!-- Effects_Distort_ApplyLens.frm contains 9 phrases. 8 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>correction type</original>
+<translation>修正タイプ</translation>
+</phrase>
+
+<phrase>
+<original>(a) edges</original>
+<translation>(エッジ</translation>
+</phrase>
+
+<phrase>
+<original>(b) midpoints</original>
+<translation>(b) 中間点</translation>
+</phrase>
+
+<phrase>
+<original>(c) whole image</original>
+<translation>(c) 全体像</translation>
+</phrase>
+
+<phrase>
+<original>(d) zoom</original>
+<translation>(d) ズーム</translation>
+</phrase>
+
+<phrase>
+<original>if pixels lie outside the corrected area</original>
+<translation>画素が補正領域外にある場合</translation>
+</phrase>
+
+<phrase>
+<original>correction strength</original>
+<translation>修正強度</translation>
+</phrase>
+
+<phrase>
+<original>correction zoom</original>
+<translation>補正ズーム</translation>
+</phrase>
+
+<phrase>
+<original>Correcting image distortion</original>
+<translation>画像の歪みを補正</translation>
+</phrase>
+
+<!-- Effects_Distort_CorrectLens.frm contains 22 phrases. 13 were duplicates of existing phrases, so only 9 new phrases were written to file. -->
+
+<phrase>
+<original>initial angle</original>
+<translation>初期角度</translation>
+</phrase>
+
+<phrase>
+<original>spread</original>
+<translation>広がり</translation>
+</phrase>
+
+<phrase>
+<original>interior radius</original>
+<translation>内部半径</translation>
+</phrase>
+
+<phrase>
+<original>Deep-frying image</original>
+<translation>画像を揚げる</translation>
+</phrase>
+
+<!-- Effects_Distort_Donut.frm contains 15 phrases. 11 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>swap order</original>
+<translation>スワップオーダー</translation>
+</phrase>
+
+<phrase>
+<original>inner radius</original>
+<translation>内半径</translation>
+</phrase>
+
+<phrase>
+<original>outer radius</original>
+<translation>外半径</translation>
+</phrase>
+
+<phrase>
+<original>Summoning M. C. Escher</original>
+<translation>M.C.エッシャーを召喚</translation>
+</phrase>
+
+<!-- Effects_Distort_Droste.frm contains 11 phrases. 7 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>Miscellaneous distorts</original>
+<translation>雑多な歪み</translation>
+</phrase>
+
+<phrase>
+<original>distortions</original>
+<translation>歪曲</translation>
+</phrase>
+
+<phrase>
+<original>Applying %1 distortion</original>
+<translation>歪み %1 の適用</translation>
+</phrase>
+
+<phrase>
+<original>emphasize center</original>
+<translation>センター重視</translation>
+</phrase>
+
+<phrase>
+<original>flatten corners</original>
+<translation>角を平らにする</translation>
+</phrase>
+
+<phrase>
+<original>pull in</original>
+<translation>引っ張る</translation>
+</phrase>
+
+<phrase>
+<original>push out</original>
+<translation>押し出す</translation>
+</phrase>
+
+<phrase>
+<original>ring</original>
+<translation>リング</translation>
+</phrase>
+
+<phrase>
+<original>twist edges</original>
+<translation>ツイストエッジ</translation>
+</phrase>
+
+<phrase>
+<original>wormhole</original>
+<translation>ワームホール</translation>
+</phrase>
+
+<!-- Effects_Distort_Miscellaneous.frm contains 22 phrases. 12 were duplicates of existing phrases, so only 10 new phrases were written to file. -->
+
+<phrase>
+<original>whirl angle</original>
+<translation>渦巻き角度</translation>
+</phrase>
+
+<phrase>
+<original>pinch amount</original>
+<translation>ピンチ量</translation>
+</phrase>
+
+<phrase>
+<original>Pinching and whirling image</original>
+<translation>画像をつまんで回す</translation>
+</phrase>
+
+<!-- Effects_Distort_Pinch.frm contains 10 phrases. 7 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>Poking image</original>
+<translation>画像を突き刺す</translation>
+</phrase>
+
+<!-- Effects_Distort_Poke.frm contains 8 phrases. 7 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>height of ripples (amplitude)</original>
+<translation>波紋の高さ (振幅)</translation>
+</phrase>
+
+<phrase>
+<original>length of ripples (wavelength)</original>
+<translation>波紋の長さ (波長)</translation>
+</phrase>
+
+<phrase>
+<original>time (phase)</original>
+<translation>じそう</translation>
+</phrase>
+
+<phrase>
+<original>Simulating ripples across image surface</original>
+<translation>画像表面の波紋をシミュレート</translation>
+</phrase>
+
+<!-- Effects_Distort_Ripple.frm contains 16 phrases. 12 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>Squeezing image</original>
+<translation>スクイーズ画像</translation>
+</phrase>
+
+<!-- Effects_Distort_Squish.frm contains 7 phrases. 6 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>Swirling image round and round</original>
+<translation>画像を渦巻く</translation>
+</phrase>
+
+<!-- Effects_Distort_Swirl.frm contains 9 phrases. 8 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>horizontal wavelength</original>
+<translation>水平波長</translation>
+</phrase>
+
+<phrase>
+<original>vertical wavelength</original>
+<translation>垂直波長</translation>
+</phrase>
+
+<phrase>
+<original>horizontal strength (amplitude)</original>
+<translation>水平強度</translation>
+</phrase>
+
+<phrase>
+<original>vertical strength (amplitude)</original>
+<translation>垂直力 (振幅)</translation>
+</phrase>
+
+<phrase>
+<original>Dipping image in virtual wave pool</original>
+<translation>仮想波のプールに画像を浸す</translation>
+</phrase>
+
+<!-- Effects_Distort_Waves.frm contains 9 phrases. 4 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<phrase>
+<original>base color</original>
+<translation>ベースカラー</translation>
+</phrase>
+
+<phrase>
+<original>Embossing image</original>
+<translation>画像のエンボス</translation>
+</phrase>
+
+<!-- Effects_Edge_Emboss.frm contains 7 phrases. 5 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>edge detection technique</original>
+<translation>エッジ検出技術</translation>
+</phrase>
+
+<phrase>
+<original>horizontal</original>
+<translation>水平</translation>
+</phrase>
+
+<phrase>
+<original>vertical</original>
+<translation>垂直</translation>
+</phrase>
+
+<phrase>
+<original>detection direction(s)</original>
+<translation>検出方向</translation>
+</phrase>
+
+<phrase>
+<original>Applying pass %1 of %2 for %3 filter</original>
+<translation>%2 個中 %1 個目のパスを %3 フィルターに適用しています。</translation>
+</phrase>
+
+<phrase>
+<original>Artistic contour edge detection</original>
+<translation>芸術的輪郭エッジ検出</translation>
+</phrase>
+
+<phrase>
+<original>Hilite edge detection</original>
+<translation>ヒライトエッジ検出</translation>
+</phrase>
+
+<phrase>
+<original>Laplacian edge detection</original>
+<translation>ラプラシアンエッジ検出</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon edge detection</original>
+<translation>PhotoDemonエッジ検出</translation>
+</phrase>
+
+<phrase>
+<original>Prewitt edge detection</original>
+<translation>プリウィット エッジ検出</translation>
+</phrase>
+
+<phrase>
+<original>Roberts cross edge detection</original>
+<translation>ロバーツのクロスエッジ検出</translation>
+</phrase>
+
+<phrase>
+<original>Sobel edge detection</original>
+<translation>ソーベル エッジ検出</translation>
+</phrase>
+
+<phrase>
+<original>Artistic contour</original>
+<translation>芸術的輪郭</translation>
+</phrase>
+
+<phrase>
+<original>Roberts cross</original>
+<translation>ロバーツ クロス</translation>
+</phrase>
+
+<!-- Effects_Edge_EnhanceEdges.frm contains 26 phrases. 12 were duplicates of existing phrases, so only 14 new phrases were written to file. -->
+
+<phrase>
+<original>use black background</original>
+<translation>黒背景を使用</translation>
+</phrase>
+
+<phrase>
+<original>other options</original>
+<translation>その他のオプション</translation>
+</phrase>
+
+<phrase>
+<original>Tracing image edges with virtual paintbrush</original>
+<translation>仮想ペイントブラシで画像のエッジをなぞる</translation>
+</phrase>
+
+<!-- Effects_Edge_FindEdges.frm contains 25 phrases. 22 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>background color and opacity</original>
+<translation>背景色と不透明度</translation>
+</phrase>
+
+<phrase>
+<original>render</original>
+<translation>レンダー</translation>
+</phrase>
+
+<phrase>
+<original>smoothing</original>
+<translation>スムージング</translation>
+</phrase>
+
+<phrase>
+<original>boost</original>
+<translation>高める</translation>
+</phrase>
+
+<phrase>
+<original>foreground color</original>
+<translation>前景色</translation>
+</phrase>
+
+<phrase>
+<original>Calculating gradient flow</original>
+<translation>勾配流の計算</translation>
+</phrase>
+
+<phrase>
+<original>magnitude</original>
+<translation>マグニチュード</translation>
+</phrase>
+
+<phrase>
+<original>direction</original>
+<translation>方向</translation>
+</phrase>
+
+<phrase>
+<original>dynamic</original>
+<translation>ダイナミック</translation>
+</phrase>
+
+<phrase>
+<original>static</original>
+<translation>静的</translation>
+</phrase>
+
+<!-- Effects_Edge_GradientFlow.frm contains 13 phrases. 3 were duplicates of existing phrases, so only 10 new phrases were written to file. -->
+
+<phrase>
+<original>synchronize search radius</original>
+<translation>検索半径の同期</translation>
+</phrase>
+
+<phrase>
+<original>horizontal radius</original>
+<translation>水平半径</translation>
+</phrase>
+
+<phrase>
+<original>vertical radius</original>
+<translation>垂直半径</translation>
+</phrase>
+
+<phrase>
+<original>Searching each pixel range for edges</original>
+<translation>各ピクセル範囲のエッジを検索</translation>
+</phrase>
+
+<!-- Effects_Edge_Range.frm contains 7 phrases. 3 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>apply contour smoothing</original>
+<translation>輪郭スムージングを適用</translation>
+</phrase>
+
+<phrase>
+<original>Tracing image contour</original>
+<translation>画像の輪郭をなぞる</translation>
+</phrase>
+
+<!-- Effects_Edge_TraceContour.frm contains 6 phrases. 4 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>Illuminating image with imaginary blacklight</original>
+<translation>架空のブラック ライトで画像を照らす</translation>
+</phrase>
+
+<!-- Effects_LightAndShadow_BlackLight.frm contains 4 phrases. 3 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>ambient light</original>
+<translation>環境光</translation>
+</phrase>
+
+<phrase>
+<original>Generating bump map</original>
+<translation>バンプマップの生成</translation>
+</phrase>
+
+<!-- Effects_LightAndShadow_BumpMap.frm contains 12 phrases. 10 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>spokes</original>
+<translation>スポーク</translation>
+</phrase>
+
+<phrase>
+<original>softness</original>
+<translation>やわらかさ</translation>
+</phrase>
+
+<phrase>
+<original>Applying cross-screen filter</original>
+<translation>クロススクリーンフィルターの適用</translation>
+</phrase>
+
+<!-- Effects_LightAndShadow_CrossScreen.frm contains 9 phrases. 6 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>saturation boost</original>
+<translation>彩度ブースト</translation>
+</phrase>
+
+<phrase>
+<original>Sprinkling image with shimmering rainbows</original>
+<translation>画像をきらめく虹にする</translation>
+</phrase>
+
+<!-- Effects_LightAndShadow_Rainbow.frm contains 7 phrases. 5 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>randomize</original>
+<translation>ランダマイズ</translation>
+</phrase>
+
+<phrase>
+<original>number of rays</original>
+<translation>光線数</translation>
+</phrase>
+
+<phrase>
+<original>color variance</original>
+<translation>色分散</translation>
+</phrase>
+
+<phrase>
+<original>ray variance</original>
+<translation>光線分散</translation>
+</phrase>
+
+<phrase>
+<original>Generating light beams</original>
+<translation>光線の発生</translation>
+</phrase>
+
+<!-- Effects_LightAndShadow_Sunshine.frm contains 14 phrases. 9 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<phrase>
+<original>Creating artificial atmosphere</original>
+<translation>人工的な雰囲気作り</translation>
+</phrase>
+
+<!-- Effects_Nature_Atmosphere.frm contains 8 phrases. 7 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>Generating artificial fog</original>
+<translation>人工霧の発生</translation>
+</phrase>
+
+<!-- Effects_Nature_Fog.frm contains 8 phrases. 7 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>color intensity</original>
+<translation>色強度</translation>
+</phrase>
+
+<phrase>
+<original>flame height</original>
+<translation>炎の高さ</translation>
+</phrase>
+
+<phrase>
+<original>Lighting image on fire</original>
+<translation>画像に火をつける</translation>
+</phrase>
+
+<!-- Effects_Nature_Ignite.frm contains 6 phrases. 3 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>Exploding imaginary volcano</original>
+<translation>爆発する想像上の火山</translation>
+</phrase>
+
+<!-- Effects_Nature_Lava.frm contains 9 phrases. 8 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>Pouring smoldering metal onto image</original>
+<translation>画像にくすぶる金属を流し込む</translation>
+</phrase>
+
+<!-- Effects_Nature_Metal.frm contains 7 phrases. 6 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>wind</original>
+<translation>風</translation>
+</phrase>
+
+<phrase>
+<original>Let it snow, let it snow, let it snow</original>
+<translation>雪を降らせろ、雪を降らせろ、雪を降らせろ</translation>
+</phrase>
+
+<!-- Effects_Nature_Snow.frm contains 9 phrases. 7 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>color shift</original>
+<translation>色ずれ</translation>
+</phrase>
+
+<phrase>
+<original>Submerging image in artificial water</original>
+<translation>画像を人工水に沈める</translation>
+</phrase>
+
+<!-- Effects_Nature_Water.frm contains 7 phrases. 5 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>appearance</original>
+<translation>表示</translation>
+</phrase>
+
+<phrase>
+<original>distribution</original>
+<translation>流通</translation>
+</phrase>
+
+<phrase>
+<original>Increasing image noise</original>
+<translation>画像ノイズの増加</translation>
+</phrase>
+
+<phrase>
+<original>uniform</original>
+<translation>ユニフォーム</translation>
+</phrase>
+
+<!-- Effects_Noise_AddRGBNoise.frm contains 10 phrases. 6 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>directionality</original>
+<translation>指向性</translation>
+</phrase>
+
+<phrase>
+<original>gradient flow</original>
+<translation>勾配流</translation>
+</phrase>
+
+<phrase>
+<original>Calculating energy gradients (pass %1 of %2)</original>
+<translation>エネルギー勾配の計算 (%2 個中 %1 個目のパス)</translation>
+</phrase>
+
+<phrase>
+<original>4-way cardinal</original>
+<translation>4方向 基本</translation>
+</phrase>
+
+<phrase>
+<original>4-way ordinal</original>
+<translation>4方向 序列</translation>
+</phrase>
+
+<phrase>
+<original>8-way</original>
+<translation>8方向</translation>
+</phrase>
+
+<phrase>
+<original>sharpen</original>
+<translation明確化</translation>
+</phrase>
+
+<phrase>
+<original>smooth</original>
+<translation>スムース</translation>
+</phrase>
+
+<!-- Effects_Noise_Anisotropic.frm contains 13 phrases. 5 were duplicates of existing phrases, so only 8 new phrases were written to file. -->
+
+<phrase>
+<original>luminance only</original>
+<translation>輝度のみ</translation>
+</phrase>
+
+<phrase>
+<original>Fixing dust and scratches</original>
+<translation>ほこりや傷の修復</translation>
+</phrase>
+
+<!-- Effects_Noise_DustAndScratches.frm contains 6 phrases. 4 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>Generating film grain texture</original>
+<translation>フィルムグレインテクスチャの生成</translation>
+</phrase>
+
+<phrase>
+<original>Softening film grain</original>
+<translation>フィルムグレインを和らげる</translation>
+</phrase>
+
+<!-- Effects_Noise_FilmGrain.frm contains 6 phrases. 4 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>Applying harmonic mean filter</original>
+<translation>高調波平均フィルターの適用</translation>
+</phrase>
+
+<!-- Effects_Noise_HarmonicMean.frm contains 7 phrases. 6 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>Applying mean shift filter</original>
+<translation>平均シフトフィルターの適用</translation>
+</phrase>
+
+<!-- Effects_Noise_MeanShift.frm contains 6 phrases. 5 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>percentile</original>
+<translation>パーセンタイル</translation>
+</phrase>
+
+<phrase>
+<original>Applying erode (minimum rank) filter</original>
+<translation>erode (最小ランク)フィルターの適用</translation>
+</phrase>
+
+<phrase>
+<original>Applying dilate (maximum rank) filter</original>
+<translation>ディレート (最大ランク)フィルターの適用</translation>
+</phrase>
+
+<phrase>
+<original>Applying median filter</original>
+<translation>メディアンフィルターの適用</translation>
+</phrase>
+
+<!-- Effects_Noise_MedianSmoothing.frm contains 15 phrases. 11 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>cyan angle</original>
+<translation>シアン角</translation>
+</phrase>
+
+<phrase>
+<original>magenta angle</original>
+<translation>マゼンタ角</translation>
+</phrase>
+
+<phrase>
+<original>yellow angle</original>
+<translation>イエローアングル</translation>
+</phrase>
+
+<phrase>
+<original>Printing image to digital halftone surface</original>
+<translation>デジタル網点画面への印刷</translation>
+</phrase>
+
+<!-- Effects_Pixelate_ColorHalftone.frm contains 8 phrases. 4 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>Crystallizing image</original>
+<translation>画像の結晶化</translation>
+</phrase>
+
+<!-- Effects_Pixelate_Crystallize.frm contains 14 phrases. 13 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>number of fragments</original>
+<translation>断片数</translation>
+</phrase>
+
+<phrase>
+<original>Calculating image fragments</original>
+<translation>画像断片の計算</translation>
+</phrase>
+
+<phrase>
+<original>manual</original>
+<translation>マニュアル</translation>
+</phrase>
+
+<!-- Effects_Pixelate_Fragment.frm contains 9 phrases. 6 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>type</original>
+<translation>タイプ</translation>
+</phrase>
+
+<phrase>
+<original>randomness</original>
+<translation>偶然性</translation>
+</phrase>
+
+<phrase>
+<original>stippling</original>
+<translation>点描</translation>
+</phrase>
+
+<phrase>
+<original>Mezzotinting image</original>
+<translation>画像のメゾチント</translation>
+</phrase>
+
+<phrase>
+<original>dot</original>
+<translation>点</translation>
+</phrase>
+
+<phrase>
+<original>horizontal stroke</original>
+<translation>横ストローク</translation>
+</phrase>
+
+<phrase>
+<original>vertical stroke</original>
+<translation>垂直ストローク</translation>
+</phrase>
+
+<phrase>
+<original>coarse</original>
+<translation>粗い</translation>
+</phrase>
+
+<phrase>
+<original>fine</original>
+<translation>ファイン</translation>
+</phrase>
+
+<!-- Effects_Pixelate_Mezzotint.frm contains 13 phrases. 4 were duplicates of existing phrases, so only 9 new phrases were written to file. -->
+
+<phrase>
+<original>synchronize block size</original>
+<translation>ブロックサイズを同期させる</translation>
+</phrase>
+
+<phrase>
+<original>block width</original>
+<translation>ブロック幅</translation>
+</phrase>
+
+<phrase>
+<original>block height</original>
+<translation>ブロックの高さ</translation>
+</phrase>
+
+<phrase>
+<original>Applying mosaic</original>
+<translation>モザイクの適用</translation>
+</phrase>
+
+<!-- Effects_Pixelate_Mosaic.frm contains 7 phrases. 3 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>Splattering canvas with paint</original>
+<translation>キャンバスに絵の具をぶちまける</translation>
+</phrase>
+
+<!-- Effects_Pixelate_Pointillize.frm contains 8 phrases. 7 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>generator</original>
+<translation>ジェネレーター</translation>
+</phrase>
+
+<phrase>
+<original>Rendering clouds</original>
+<translation>雲のレンダリング</translation>
+</phrase>
+
+<phrase>
+<original>simple</original>
+<translation>シンプル</translation>
+</phrase>
+
+<!-- Effects_Render_Clouds.frm contains 15 phrases. 12 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>length</original>
+<translation>長さ</translation>
+</phrase>
+
+<phrase>
+<original>grain</original>
+<translation>穀物</translation>
+</phrase>
+
+<phrase>
+<original>Rendering fibers</original>
+<translation>レンダリングファイバー</translation>
+</phrase>
+
+<!-- Effects_Render_Fibers.frm contains 16 phrases. 13 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>Truchet tiles</original>
+<translation>トルシェ タイル</translation>
+</phrase>
+
+<phrase>
+<original>Rendering Truchet tiles</original>
+<translation>トルシェ タイルのレンダリング</translation>
+</phrase>
+
+<!-- Effects_Render_Truchet.frm contains 10 phrases. 8 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<!-- Effects_Sharpen_Sharpen.frm contains 5 phrases.  All were duplicates of existing phrases, so no new phrases were written to file. -->
+
+<phrase>
+<original>amount</original>
+<translation>量</translation>
+</phrase>
+
+<phrase>
+<original>Applying unsharp mask (step %1 of %2)</original>
+<translation>アンシャープ マスクを適用しています (ステップ %1 / %2)</translation>
+</phrase>
+
+<!-- Effects_Sharpen_UnsharpMask.frm contains 10 phrases. 8 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>color fade</original>
+<translation>色フェード</translation>
+</phrase>
+
+<phrase>
+<original>diffuse light</original>
+<translation>拡散光</translation>
+</phrase>
+
+<phrase>
+<original>fade edges</original>
+<translation>フェード エッジ</translation>
+</phrase>
+
+<phrase>
+<original>Sending image back in time</original>
+<translation>画像を過去に送る</translation>
+</phrase>
+
+<!-- Effects_Stylize_Antique.frm contains 7 phrases. 3 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>wrap edge values</original>
+<translation>エッジのラップ値</translation>
+</phrase>
+
+<phrase>
+<original>Simulating large image explosion</original>
+<translation>大きな画像の爆発をシミュレート</translation>
+</phrase>
+
+<!-- Effects_Stylize_Diffuse.frm contains 6 phrases. 4 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>edge type</original>
+<translation>エッジタイプ</translation>
+</phrase>
+
+<phrase>
+<original>Generating image outline</original>
+<translation>画像アウトラインの生成</translation>
+</phrase>
+
+<!-- Effects_Stylize_Outline.frm contains 9 phrases. 7 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>use Lab color space</original>
+<translation>Lab カラースペースを使用</translation>
+</phrase>
+
+<phrase>
+<original>quantization method</original>
+<translation>量子化法</translation>
+</phrase>
+
+<phrase>
+<original>preserve white and black</original>
+<translation>白と黒を保つ</translation>
+</phrase>
+
+<phrase>
+<original>palette type</original>
+<translation>パレットタイプ</translation>
+</phrase>
+
+<phrase>
+<original>use palette's alpha values</original>
+<translation>パレットのアルファ値を使う</translation>
+</phrase>
+
+<phrase>
+<original>palettes in this file</original>
+<translation>このファイルのパレット</translation>
+</phrase>
+
+<phrase>
+<original>choose a palette file</original>
+<translation>パレット ファイルを選択</translation>
+</phrase>
+
+<phrase>
+<original>optimal</original>
+<translation>最適</translation>
+</phrase>
+
+<phrase>
+<original>from file</original>
+<translation>ファイルから</translation>
+</phrase>
+
+<phrase>
+<original>median cut</original>
+<translation>メディアンカット</translation>
+</phrase>
+
+<phrase>
+<original>neural network</original>
+<translation>ニューラルネットワーク</translation>
+</phrase>
+
+<phrase>
+<original>color only (RGB)</original>
+<translation>色のみ (RGB)</translation>
+</phrase>
+
+<phrase>
+<original>color and opacity (RGBA)</original>
+<translation>色と不透明度 (RGBA)</translation>
+</phrase>
+
+<phrase>
+<original>Generating optimal palette</original>
+<translation>最適なパレットの生成</translation>
+</phrase>
+
+<phrase>
+<original>Applying new palette to image</original>
+<translation>画像に新しいパレットを適用</translation>
+</phrase>
+
+<phrase>
+<original>%1 (%2 colors)</original>
+<translation>%1 (%2 色)</translation>
+</phrase>
+
+<phrase>
+<original>WARNING!  Palette file invalid.</original>
+<translation>警告!  パレット ファイルが無効です。</translation>
+</phrase>
+
+<!-- Effects_Stylize_Palettize.frm contains 31 phrases. 14 were duplicates of existing phrases, so only 17 new phrases were written to file. -->
+
+<phrase>
+<original>glow radius</original>
+<translation>グロー半径</translation>
+</phrase>
+
+<phrase>
+<original>exposure boost</original>
+<translation>露出度アップ</translation>
+</phrase>
+
+<phrase>
+<original>Applying petroleum jelly to camera lens</original>
+<translation>カメラのレンズにワセリンを塗る</translation>
+</phrase>
+
+<phrase>
+<original>classic</original>
+<translation>クラシック</translation>
+</phrase>
+
+<phrase>
+<original>subtle</original>
+<translation>微妙</translation>
+</phrase>
+
+<!-- Effects_Stylize_PortraitGlow.frm contains 10 phrases. 5 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<phrase>
+<original>Solarizing image</original>
+<translation>画像のソラリゼーション</translation>
+</phrase>
+
+<!-- Effects_Stylize_Solarize.frm contains 4 phrases. 3 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>orientation</original>
+<translation>方向</translation>
+</phrase>
+
+<phrase>
+<original>Generating image twin</original>
+<translation>ツイン画像の生成</translation>
+</phrase>
+
+<!-- Effects_Stylize_Twins.frm contains 6 phrases. 4 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>Applying vignetting</original>
+<translation>ヴィネットの適用</translation>
+</phrase>
+
+<phrase>
+<original>fit to image</original>
+<translation>画像に合せる</translation>
+</phrase>
+
+<phrase>
+<original>circular</original>
+<translation>サーキュラー</translation>
+</phrase>
+
+<!-- Effects_Stylize_Vignette.frm contains 15 phrases. 12 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>horizontal offset</original>
+<translation>水平オフセット</translation>
+</phrase>
+
+<phrase>
+<original>vertical offset</original>
+<translation>垂直オフセット</translation>
+</phrase>
+
+<phrase>
+<original>zoom</original>
+<translation>ズーム</translation>
+</phrase>
+
+<phrase>
+<original>Applying pan and zoom (Ken Burns) effect</original>
+<translation>パン &amp; ズーム (ケン・バーンズ) 効果の適用</translation>
+</phrase>
+
+<!-- Effects_Transform_PanZoom.frm contains 8 phrases. 4 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>coordinates (x, y)</original>
+<translation>座標 (x, y)</translation>
+</phrase>
+
+<phrase>
+<original>transformation type</original>
+<translation>変換タイプ</translation>
+</phrase>
+
+<phrase>
+<original>Applying new perspective</original>
+<translation>新たな視点の適用</translation>
+</phrase>
+
+<phrase>
+<original>forward (outline defines destination area)</original>
+<translation>前進 (アウトラインは目的地を定義する)</translation>
+</phrase>
+
+<phrase>
+<original>reverse (outline defines source area)</original>
+<translation>リバース (アウトラインはソースエリアを定義する)</translation>
+</phrase>
+
+<phrase>
+<original>top-left</original>
+<translation>左上</translation>
+</phrase>
+
+<phrase>
+<original>top-right</original>
+<translation>右上</translation>
+</phrase>
+
+<phrase>
+<original>bottom-right</original>
+<translation>右下</translation>
+</phrase>
+
+<phrase>
+<original>bottom-left</original>
+<translation>左下</translation>
+</phrase>
+
+<!-- Effects_Transform_Perspective.frm contains 17 phrases. 8 were duplicates of existing phrases, so only 9 new phrases were written to file. -->
+
+<phrase>
+<original>swap x and y coordinates</original>
+<translation>x 座標と y 座標を入れ替える</translation>
+</phrase>
+
+<phrase>
+<original>conversion</original>
+<translation>コンバージョン</translation>
+</phrase>
+
+<phrase>
+<original>Performing polar coordinate conversion</original>
+<translation>極座標変換の実行</translation>
+</phrase>
+
+<phrase>
+<original>Rectangular to polar</original>
+<translation>長方形から極座標へ</translation>
+</phrase>
+
+<phrase>
+<original>Polar to rectangular</original>
+<translation>ポーラーからレクタンギュラーへ</translation>
+</phrase>
+
+<phrase>
+<original>Polar inversion</original>
+<translation>極性反転</translation>
+</phrase>
+
+<!-- Effects_Transform_PolarCoords.frm contains 13 phrases. 7 were duplicates of existing phrases, so only 6 new phrases were written to file. -->
+
+<phrase>
+<original>Rotating area</original>
+<translation>回転エリア</translation>
+</phrase>
+
+<phrase>
+<original>If you want to enlarge the canvas to fit the rotated image, please use the Image -> Rotate menu instead.</original>
+<translation>回転した画像に合わせてキャンバスを拡大したい場合は、代わりに [画像] -> [回転] メニューを使用してください。</translation>
+</phrase>
+
+<!-- Effects_Transform_Rotate.frm contains 12 phrases. 10 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
+
+<phrase>
+<original>horizontal angle</original>
+<translation>水平角</translation>
+</phrase>
+
+<phrase>
+<original>vertical angle</original>
+<translation>ちょうかく</translation>
+</phrase>
+
+<phrase>
+<original>Shearing image</original>
+<translation>シャーリング画像</translation>
+</phrase>
+
+<!-- Effects_Transform_Shear.frm contains 7 phrases. 4 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>area outside sphere</original>
+<translation>球外領域</translation>
+</phrase>
+
+<phrase>
+<original>Wrapping image around sphere</original>
+<translation>球体に画像を巻き付ける</translation>
+</phrase>
+
+<phrase>
+<original>rays of light</original>
+<translation>光線</translation>
+</phrase>
+
+<!-- Effects_Transform_Sphere.frm contains 11 phrases. 8 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>Batch repair</original>
+<translation>バッチ修復</translation>
+</phrase>
+
+<phrase>
+<original>include subfolders</original>
+<translation>サブ フォルダを含む</translation>
+</phrase>
+
+<phrase>
+<original>click OK to begin the repair operation</original>
+<translation>OK をクリックして修復作業を開始</translation>
+</phrase>
+
+<phrase>
+<original>attempt to repair image files</original>
+<translation>画像ファイルの修復を試みる</translation>
+</phrase>
+
+<phrase>
+<original>source folder</original>
+<translation>ソースフォルダ</translation>
+</phrase>
+
+<phrase>
+<original>destination folder (for repaired files only)</original>
+<translation>保存先フォルダ (修復済みファイルのみ)</translation>
+</phrase>
+
+<phrase>
+<original>repair options</original>
+<translation>修復オプション</translation>
+</phrase>
+
+<phrase>
+<original>progress</original>
+<translation>進捗</translation>
+</phrase>
+
+<phrase>
+<original>attempt to repair video and audio files</original>
+<translation>ビデオやオーディオ ファイルの修復を試みる</translation>
+</phrase>
+
+<phrase>
+<original>overwrite matching filenames in the destination folder</original>
+<translation>コピー先フォルダ内の一致するファイル名を上書き</translation>
+</phrase>
+
+<phrase>
+<original>after a successful recovery, erase the original (unrepaired) file</original>
+<translation>復元に成功したら、元の (修復されていない) ファイルを消去</translation>
+</phrase>
+
+<phrase>
+<original>generating list of files to repair</original>
+<translation>修復するファイルのリストを作成</translation>
+</phrase>
+
+<phrase>
+<original>processing file %1 of %2 (%3 repairs performed)</original>
+<translation>%2 個中 %1 個目のファイルを処理中 (%3 個の修復を実行)</translation>
+</phrase>
+
+<phrase>
+<original>Repairs complete.  %1 files repaired.</original>
+<translation>修復が完了しました。  %1 個のファイルが修復されました。</translation>
+</phrase>
+
+<phrase>
+<original>%1 files(s) repaired.
+
+Repaired files have been saved to the destination folder.  Unrepaired files remain in their original locations.</original>
+<translation>%1 個のファイルが修復されました。
+
+修復されたファイルが宛先フォルダに保存されました。  修復されなかったファイルは元の場所に残ります。</translation>
+</phrase>
+
+<phrase>
+<original>Repairs complete</original>
+<translation>修復が完了しました</translation>
+</phrase>
+
+<phrase>
+<original>The source folder does not contain any files.  Please try another folder.</original>
+<translation>ソースフォルダにファイルがありません。  別のフォルダを試してください。</translation>
+</phrase>
+
+<phrase>
+<original>No files found</original>
+<translation>ファイルが見つかりません</translation>
+</phrase>
+
+<!-- File_BatchRepair.frm contains 23 phrases. 5 were duplicates of existing phrases, so only 18 new phrases were written to file. -->
+
+<phrase>
+<original>Previous</original>
+<translation>前へ</translation>
+</phrase>
+
+<phrase>
+<original>Next</original>
+<translation>次へ</translation>
+</phrase>
+
+<phrase>
+<original>Step 1: select the photo editing action(s) to apply to each image</original>
+<translation>ステップ 1: 各画像に適用する写真編集アクションを選択</translation>
+</phrase>
+
+<phrase>
+<original>current batch list</original>
+<translation>現在のバッチ リスト</translation>
+</phrase>
+
+<phrase>
+<original>save list</original>
+<translation>リストを保存</translation>
+</phrase>
+
+<phrase>
+<original>load list</original>
+<translation>リストを読み込み</translation>
+</phrase>
+
+<phrase>
+<original>erase entire list</original>
+<translation>リストを全消去</translation>
+</phrase>
+
+<phrase>
+<original>remove selected image</original>
+<translation>選択画像を除去</translation>
+</phrase>
+
+<phrase>
+<original>add individual images</original>
+<translation>個々の画像を追加</translation>
+</phrase>
+
+<phrase>
+<original>show image previews</original>
+<translation>画像のプレビューを表示</translation>
+</phrase>
+
+<phrase>
+<original>add images</original>
+<translation>画像を追加</translation>
+</phrase>
+
+<phrase>
+<original>modify list</original>
+<translation>リストの変更</translation>
+</phrase>
+
+<phrase>
+<original>load / save list</original>
+<translation>リストの読み込み / 保存</translation>
+</phrase>
+
+<phrase>
+<original>add entire folder(s)</original>
+<translation>フォルダ全体を追加</translation>
+</phrase>
+
+<phrase>
+<original>remove all images in this folder</original>
+<translation>このフォルダ内の画像をすべて除去</translation>
+</phrase>
+
+<phrase>
+<original>(batch conversion process will appear here at run-time)</original>
+<translation>(バッチ変換処理は実行時にここに表示されます)</translation>
+</phrase>
+
+<phrase>
+<original>preserve input folder structure</original>
+<translation>入力フォルダ構造を保持</translation>
+</phrase>
+
+<phrase>
+<original>Select destination folder</original>
+<translation>保存先フォルダの選択</translation>
+</phrase>
+
+<phrase>
+<original>lowercase</original>
+<translation>小文字</translation>
+</phrase>
+
+<phrase>
+<original>add a prefix to each filename</original>
+<translation>各ファイル名に接頭辞を付ける</translation>
+</phrase>
+
+<phrase>
+<original>add a suffix to each filename</original>
+<translation>各ファイル名に接尾辞を付ける</translation>
+</phrase>
+
+<phrase>
+<original>remove the following text (if found) from each filename</original>
+<translation>各ファイル名から以下のテキストを (含まれる場合) 除去</translation>
+</phrase>
+
+<phrase>
+<original>force each filename, including extension, to the following case</original>
+<translation>拡張子を含む各ファイル名を以下のケースに強制的に変換</translation>
+</phrase>
+
+<phrase>
+<original>UPPERCASE</original>
+<translation>大文字</translation>
+</phrase>
+
+<phrase>
+<original>replace spaces in filenames with underscores</original>
+<translation>ファイル名のスペースをアンダースコアに置き換える</translation>
+</phrase>
+
+<phrase>
+<original>use case-sensitive matching</original>
+<translation>大文字と小文字を区別</translation>
+</phrase>
+
+<phrase>
+<original>after images are processed, save them with the following name</original>
+<translation>画像が処理されたら、次の名前で保存</translation>
+</phrase>
+
+<phrase>
+<original>additional rename options</original>
+<translation>リネームの追加オプション</translation>
+</phrase>
+
+<phrase>
+<original>output images to this folder</original>
+<translation>このフォルダに画像を出力</translation>
+</phrase>
+
+<phrase>
+<original>auto-detect animated images</original>
+<translation>アニメーション画像の自動検出</translation>
+</phrase>
+
+<phrase>
+<original>set export settings for this format</original>
+<translation>このフォーマットのエクスポート設定を行う</translation>
+</phrase>
+
+<phrase>
+<original>keep images in their original format</original>
+<translation>画像を元のフォーマットのまま保存</translation>
+</phrase>
+
+<phrase>
+<original>convert all images to a new format</original>
+<translation>すべての画像を新しいフォーマットに変換</translation>
+</phrase>
+
+<phrase>
+<original>set export settings for animated images</original>
+<translation>アニメーション画像のエクスポート設定</translation>
+</phrase>
+
+<phrase>
+<original>apply photo editing actions</original>
+<translation>写真編集アクションを適用</translation>
+</phrase>
+
+<phrase>
+<original>if you only want to rename images or change image formats, use this option</original>
+<translation>画像名の変更や画像フォーマットの変更のみを行う場合は、このオプションを使用します。</translation>
+</phrase>
+
+<phrase>
+<original>resize image by</original>
+<translation>画像サイズ変更</translation>
+</phrase>
+
+<phrase>
+<original>Select macro</original>
+<translation>マクロを選択</translation>
+</phrase>
+
+<phrase>
+<original>apply other actions from a saved macro file</original>
+<translation>保存したマクロ ファイルから他のアクションを適用</translation>
+</phrase>
+
+<phrase>
+<original>resize images</original>
+<translation>画像のリサイズ</translation>
+</phrase>
+
+<phrase>
+<original>fix exposure and lighting problems</original>
+<translation>露出と照明の問題を解決</translation>
+</phrase>
+
+<phrase>
+<original>previews disabled</original>
+<translation>プレビュー無効</translation>
+</phrase>
+
+<phrase>
+<original>Are you sure you want to cancel the current batch process?</original>
+<translation>本当に現在のバッチ処理をキャンセルしますか?</translation>
+</phrase>
+
+<phrase>
+<original>Cancel batch processing</original>
+<translation>バッチ処理のキャンセル</translation>
+</phrase>
+
+<phrase>
+<original>If you exit now, your batch list (the list of images to be processed) will be lost.  By saving your list, you can easily resume this batch operation at a later date.
+
+Would you like to save your batch list before exiting?</original>
+<translation>ここで終了すると、バッチ リスト (処理する画像のリスト) は失われます。  リストを保存しておけば、後日簡単にバッチ処理を再開できます。
+
+終了する前にバッチ リストを保存しますか?</translation>
+</phrase>
+
+<phrase>
+<original>Batch Image List</original>
+<translation>バッチ画像リスト</translation>
+</phrase>
+
+<phrase>
+<original>Load a list of images</original>
+<translation>画像のリストを読み込む</translation>
+</phrase>
+
+<phrase>
+<original>You have already created a list of images for processing.  The list of images inside this file will be appended to the bottom of your current list.</original>
+<translation>処理する画像のリストはすでに作成されています。  このファイル内の画像リストは、現在のリストの下に追加されます。</translation>
+</phrase>
+
+<phrase>
+<original>Batch process notification</original>
+<translation>バッチ処理通知</translation>
+</phrase>
+
+<phrase>
+<original>This is not a valid list of images. Please try a different file.</original>
+<translation>これは有効な画像リストではありません。別のファイルをお試しください。</translation>
+</phrase>
+
+<phrase>
+<original>Invalid list file</original>
+<translation>無効なリストファイル</translation>
+</phrase>
+
+<phrase>
+<original>no macro selected</original>
+<translation>マクロ未選択</translation>
+</phrase>
+
+<phrase>
+<original>You have requested that a macro be applied to each image, but no macro file has been selected.  Please select a valid macro file.</original>
+<translation>各画像にマクロを適用するようリクエストされましたが、マクロ ファイルが選択されていません。  有効なマクロ ファイルを選択してください。</translation>
+</phrase>
+
+<phrase>
+<original>No macro file selected</original>
+<translation>マクロ ファイルが選択されていない</translation>
+</phrase>
+
+<phrase>
+<original>You have not selected any images to process!  Please add one or more images to the batch list.</original>
+<translation>処理する画像が選択されていません!  バッチ リストに 1 つ以上の画像を追加してください。</translation>
+</phrase>
+
+<phrase>
+<original>No images selected</original>
+<translation>画像が選択されていない</translation>
+</phrase>
+
+<phrase>
+<original>Before proceeding, you need to click the "set export settings for this format" button to specify what export settings you want to use.</original>
+<translation>次に進む前に、"Set export settings for this format "ボタンをクリックして、使用するエクスポート設定を指定する必要があります。</translation>
+</phrase>
+
+<phrase>
+<original>Export settings required</original>
+<translation>必要なエクスポート設定</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon cannot access the requested output folder.  Please select a non-system, unrestricted folder for the batch process.</original>
+<translation>PhotoDemon は要求された出力フォルダにアクセスできません。  バッチ処理のために、非システム、制限のないフォルダを選択してください。</translation>
+</phrase>
+
+<phrase>
+<original>Folder access unavailable</original>
+<translation>フォルダにアクセスできません</translation>
+</phrase>
+
+<phrase>
+<original>Start processing!</original>
+<translation>処理を開始する!</translation>
+</phrase>
+
+<phrase>
+<original>Welcome to PhotoDemon's batch wizard.  This tool can be used to edit multiple images at once, in what is called a "batch process".</original>
+<translation>PhotoDemon のバッチ ウィザードへようこそ。  このツールは、複数の画像を一度に編集する "バッチ処理" が行えます。</translation>
+</phrase>
+
+<phrase>
+<original>Start by selecting the photo editing action(s) you want to apply.  If multiple actions are selected, they will be applied in the order they appear on this page.</original>
+<translation>適用したい写真編集アクションを選択します。  複数のアクションを選択した場合は、このページに表示されている順番に適用されます。</translation>
+</phrase>
+
+<phrase>
+<original>Note: a "macro" is simply a list of photo editing actions.  It can include any adjustment, filter, or effect in the main program.  You can create a new macro by using the "Tools -> Macros -> Record new macro" menu in the main PhotoDemon window.</original>
+<translation>注: 「マクロ」とは、単に写真の編集アクションのリストのことです。  メイン プログラムの調整、フィルター、またはエフェクトを含むことができます。  PhotoDemon のメイン ウィンドウの 「[ツール] -> [マクロを作成] -> [記録を開始]」 メニューを使用して、新しいマクロを作成できます。</translation>
+</phrase>
+
+<phrase>
+<original>In the next step, you will select the images you want to process.</original>
+<translation>次のステップでは、処理したい画像を選択します。</translation>
+</phrase>
+
+<phrase>
+<original>Step 2: prepare the batch list (the list of images to be processed)</original>
+<translation>ステップ 2: バッチ リスト (処理する画像のリスト) を用意</translation>
+</phrase>
+
+<phrase>
+<original>You can add files to the batch list in two ways</original>
+<translation>バッチ リストにファイルを追加するには、次の 2 つの方法があります</translation>
+</phrase>
+
+<phrase>
+<original>1) By manually adding one or more image file(s) using a standard Open Image dialog.</original>
+<translation>1) 標準の「画像を開く」ダイアログを使用して、1つまたは複数の画像ファイルを手動で追加します。</translation>
+</phrase>
+
+<phrase>
+<original>2) By adding entire folders at once.  Image file(s) inside the folder (or subfolders, if selected) will be automatically identified.</original>
+<translation>2) フォルダー全体を一度に追加する方法。  フォルダ (選択されている場合はサブ フォルダ) 内の画像ファイルは自動的に識別されます。</translation>
+</phrase>
+
+<phrase>
+<original>In the next step, you will choose how you want the processed images saved.</original>
+<translation>次のステップでは、処理した画像の保存方法を選択します。</translation>
+</phrase>
+
+<phrase>
+<original>Step 3: choose a destination image format</original>
+<translation>ステップ 3: 保存先画像フォーマットの選択</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon needs to know which format to use when saving the images in your batch list.</original>
+<translation>PhotoDemon は、バッチ リスト内の画像を保存する際に使用するフォーマットを知る必要があります。</translation>
+</phrase>
+
+<phrase>
+<original>If "keep images in their original format" is selected, PhotoDemon will attempt to save each image in its original format.  If the original format is not supported, a standard format (JPEG or PNG, depending on color depth) will be used.</original>
+<translation>"画像を元のフォーマットのまま保存" が選択された場合、PhotoDemon は各画像を元のフォーマットで保存しようとします。  元のフォーマットがサポートされていない場合、標準のフォーマット (色深度により JPEG または PNG) が使用されます。</translation>
+</phrase>
+
+<phrase>
+<original>If you choose to save images to a new format, please make sure the format you have selected is appropriate for all images in your list.  (For example, images with transparency should be saved to a format that supports transparency!)</original>
+<translation>画像を新しいフォーマットで保存する場合は、選択したフォーマットがリスト内のすべての画像に適していることを確認してください。  (例えば、透明度のある画像は、透明度をサポートするフォーマットに保存する必要があります!)</translation>
+</phrase>
+
+<phrase>
+<original>In the final step, you will choose how you want the saved files to be named.</original>
+<translation>最後のステップでは、保存するファイルの名前を決めます。</translation>
+</phrase>
+
+<phrase>
+<original>Step 4: provide a destination folder and any renaming options</original>
+<translation>ステップ 4: 保存先フォルダと任意のリネーム オプションを指定</translation>
+</phrase>
+
+<phrase>
+<original>In this final step, PhotoDemon needs to know where to save the processed images, and what name to give the new files.</original>
+<translation>この最後のステップでは、PhotoDemon は処理された画像を保存する場所と新しいファイル名を知る必要があります。</translation>
+</phrase>
+
+<phrase>
+<original>For your convenience, a number of standard renaming options are also provided.  Note that all items under "additional rename options" are optional.</original>
+<translation>便宜上、標準的なリネーム オプションもいくつか用意されています。  「リネームの追加オプション」の項目は、すべて必須ではないことに注意してください。</translation>
+</phrase>
+
+<phrase>
+<original>Finally, if two or more images in the batch list have the same filename, and the "original filenames" option is selected, such files will automatically be given unique filenames upon saving (e.g. "original-filename (2)").</original>
+<translation>最後に、バッチ リスト内の 2 つ以上の画像のファイル名が同じで、"元のファイル名" オプションが選択されている場合、そのようなファイルは保存時に自動的に一意のファイル名が付けられます ("元のファイル名 (2) "など)。</translation>
+</phrase>
+
+<phrase>
+<original>Step 5: wait for batch processing to finish</original>
+<translation>ステップ 5: バッチ処理の終了を待っています</translation>
+</phrase>
+
+<phrase>
+<original>Batch processing is now underway.</original>
+<translation>バッチ処理が進行中です。</translation>
+</phrase>
+
+<phrase>
+<original>Once the batch processor has processed several images, it will display an estimated time remaining.</original>
+<translation>バッチ プロセッサーが数枚の画像を処理すると、残り時間の目安が表示されます。</translation>
+</phrase>
+
+<phrase>
+<original>You can cancel batch processing at any time by pressing the "Cancel" button in the bottom-right corner.  If you choose to cancel, any processed images will still be present in the output folder, so you may need to remove them manually.</original>
+<translation>バッチ処理は、右下の "キャンセル" ボタンを押すことで、いつでもキャンセルできます。  キャンセルを選択した場合でも、処理済みの画像は出力フォルダに残っているため、手動で削除する必要があります。</translation>
+</phrase>
+
+<phrase>
+<original>Save the current list of images</original>
+<translation>現在の画像リストを保存</translation>
+</phrase>
+
+<phrase>
+<original>You haven't selected any image files.  Please add one or more files to the batch list before saving.</original>
+<translation>画像ファイルが選択されていません。  保存する前に、1 つ以上のファイルをバッチ リストに追加してください。</translation>
+</phrase>
+
+<phrase>
+<original>Empty image list</original>
+<translation>空の画像リスト</translation>
+</phrase>
+
+<phrase>
+<original>no</original>
+<translation>いいえ</translation>
+</phrase>
+
+<phrase>
+<original>stretching to fit</original>
+<translation>引き伸ばしてフィット</translation>
+</phrase>
+
+<phrase>
+<original>fit inclusively</original>
+<translation>枠内に収めてフィット</translation>
+</phrase>
+
+<phrase>
+<original>fit exclusively</original>
+<translation>枠外にはみ出してフィット</translation>
+</phrase>
+
+<phrase>
+<original>Original filenames</original>
+<translation>元のファイル名</translation>
+</phrase>
+
+<phrase>
+<original>Ascending numbers (1, 2, 3, etc.)</original>
+<translation>昇順の数字 (1、2、3など)</translation>
+</phrase>
+
+<phrase>
+<original>if PhotoDemon does not support an image's original format, a standard format will be used</original>
+<translation>PhotoDemon が画像の元のフォーマットをサポートしない場合、標準のフォーマットが使用されます。</translation>
+</phrase>
+
+<phrase>
+<original>( specifically, JPEG at 92% quality for photographs, and lossless PNG for non-photographs )</original>
+<translation>(具体的には、写真の場合は92%の画質のJPEG、写真以外の場合はロスレスPNG)</translation>
+</phrase>
+
+<phrase>
+<original>batch list</original>
+<translation>バッチ リスト</translation>
+</phrase>
+
+<phrase>
+<original>item</original>
+<translation>項目</translation>
+</phrase>
+
+<phrase>
+<original>items</original>
+<translation>項目</translation>
+</phrase>
+
+<phrase>
+<original>Preparing batch processing engine</original>
+<translation>バッチ処理エンジンの準備</translation>
+</phrase>
+
+<phrase>
+<original>Processing image # %1 of %2</original>
+<translation>%2 個中 %1 個目の画像を処理しています。</translation>
+</phrase>
+
+<phrase>
+<original>%1 files were successfully processed!</original>
+<translation>%1 個のファイルが正常に処理されました!</translation>
+</phrase>
+
+<phrase>
+<original>Batch conversion canceled.  %1 image(s) were processed before cancelation.  Last processed image was "%2".</original>
+<translation>バッチ変換がキャンセルされました。  キャンセル前に %1 画像が処理されました。  最後に処理された画像は "%2" です。</translation>
+</phrase>
+
+<phrase>
+<original>Estimated time remaining: %1:%2</original>
+<translation>推定残り時間: %1:%2</translation>
+</phrase>
+
+<phrase>
+<original>Estimating time remaining</original>
+<translation>残り時間の推定</translation>
+</phrase>
+
+<!-- File_BatchWizard.frm contains 177 phrases. 74 were duplicates of existing phrases, so only 103 new phrases were written to file. -->
+
+<phrase>
+<original>alpha cut-off</original>
+<translation>アルファ カット オフ</translation>
+</phrase>
+
+<phrase>
+<original>matte</original>
+<translation>マット</translation>
+</phrase>
+
+<phrase>
+<original>advanced settings</original>
+<translation>詳細設定</translation>
+</phrase>
+
+<phrase>
+<original>repeat count</original>
+<translation>繰り返し回数</translation>
+</phrase>
+
+<phrase>
+<original>animation speed</original>
+<translation>アニメーション速度</translation>
+</phrase>
+
+<phrase>
+<original>Waiting for user to specify export options</original>
+<translation>ユーザーがエクスポート オプションを指定するのを待っています</translation>
+</phrase>
+
+<phrase>
+<original>forever</original>
+<translation>永久</translation>
+</phrase>
+
+<phrase>
+<original>fixed</original>
+<translation>固定</translation>
+</phrase>
+
+<phrase>
+<original>pull from layer names</original>
+<translation>レイヤー名で定義</translation>
+</phrase>
+
+<phrase>
+<original>This button only affects the preview above.  The repeat setting on the right is what will be used by the exported image file.</original>
+<translation>このボタンは上のプレビューにのみ影響します。 右側のリピート設定は、エクスポートされた画像ファイルで使用されるものです。</translation>
+</phrase>
+
+<phrase>
+<original>frame time (in ms)</original>
+<translation>フレーム時間 (ミリ秒)</translation>
+</phrase>
+
+<phrase>
+<original>frame time for undefined layers (in ms)</original>
+<translation>未定義レイヤーのフレーム時間 (ミリ秒)</translation>
+</phrase>
+
+<!-- File_Export_AnimatedGIF.frm contains 23 phrases. 11 were duplicates of existing phrases, so only 12 new phrases were written to file. -->
+
+<phrase>
+<original>compression level</original>
+<translation>圧縮レベル</translation>
+</phrase>
+
+<!-- File_Export_AnimatedPNG.frm contains 18 phrases. 17 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>compression</original>
+<translation>圧縮</translation>
+</phrase>
+
+<phrase>
+<original>balanced</original>
+<translation>中間</translation>
+</phrase>
+
+<phrase>
+<original>best</original>
+<translation>最良</translation>
+</phrase>
+
+<!-- File_Export_AnimatedWebP.frm contains 22 phrases. 19 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>description</original>
+<translation>説明</translation>
+</phrase>
+
+<phrase>
+<original>copyright</original>
+<translation>著作権</translation>
+</phrase>
+
+<phrase>
+<original>grid points</original>
+<translation>グリッド ポイント</translation>
+</phrase>
+
+<phrase>
+<original>extreme</original>
+<translation>極度</translation>
+</phrase>
+
+<!-- File_Export_LUT.frm contains 10 phrases. 6 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>Palette export options</original>
+<translation>パレット書き出しオプション</translation>
+</phrase>
+
+<phrase>
+<original>target palette file</original>
+<translation>対象のパレット ファイル</translation>
+</phrase>
+
+<phrase>
+<original>palette name</original>
+<translation>パレット名</translation>
+</phrase>
+
+<phrase>
+<original>color count</original>
+<translation>色数</translation>
+</phrase>
+
+<phrase>
+<original>palette color count</original>
+<translation>パレット色数</translation>
+</phrase>
+
+<phrase>
+<original>palette contents</original>
+<translation>パレット内容</translation>
+</phrase>
+
+<phrase>
+<original>palette to export</original>
+<translation>エクスポートするパレット</translation>
+</phrase>
+
+<phrase>
+<original>current palette</original>
+<translation>カレントパレット</translation>
+</phrase>
+
+<phrase>
+<original>original embedded palette</original>
+<translation>元の埋め込みパレット</translation>
+</phrase>
+
+<phrase>
+<original>overwrite</original>
+<translation>オーバーライト</translation>
+</phrase>
+
+<phrase>
+<original>append</original>
+<translation>アペンド</translation>
+</phrase>
+
+<phrase>
+<original>Adobe Swatch Exchange (ASE) files can store multiple palettes inside a single file.  If you select the "append" option, PhotoDemon will add this palette to your existing ASE file.  Any palettes already inside the file will not be modified.</original>
+<translation>Adobe Swatch Exchange (ASE)ファイルは、1つのファイル内に複数のパレットを保存できます。  「追加」オプションを選択すると、PhotoDemon はこのパレットを既存のASEファイルに追加します。  既にファイル内にあるパレットは変更されません。</translation>
+</phrase>
+
+<!-- File_Export_Palette.frm contains 17 phrases. 5 were duplicates of existing phrases, so only 12 new phrases were written to file. -->
+
+<phrase>
+<original>Download image</original>
+<translation>画像をダウンロード</translation>
+</phrase>
+
+<phrase>
+<original>full download path (must begin with "http://" or "ftp://")</original>
+<translation>完全なダウンロードパス ("http://" または "ftp://" で始まる必要があります。)</translation>
+</phrase>
+
+<phrase>
+<original>Image download canceled.</original>
+<translation>画像のダウンロードはキャンセルされました。</translation>
+</phrase>
+
+<phrase>
+<original>Image download complete.</original>
+<translation>画像のダウンロードが完了しました。</translation>
+</phrase>
+
+<phrase>
+<original>This URL is not valid.  Please make sure the URL begins with "http://" or "ftp://".</original>
+<translation>この URL は無効です。  URL の先頭が "http://" または "ftp://" であることを確認してください。</translation>
+</phrase>
+
+<phrase>
+<original>Invalid URL</original>
+<translation>無効な URL</translation>
+</phrase>
+
+<phrase>
+<original>Please be respectful of copyrights when downloading images.  Thanks!</original>
+<translation>画像をダウンロードする際は、著作権を尊重してください。  ありがとう!</translation>
+</phrase>
+
+<phrase>
+<original>Waiting for user input</original>
+<translation>ユーザーの入力を待っています</translation>
+</phrase>
+
+<!-- File_Import_FromInternet.frm contains 9 phrases.  One was a duplicate of an existing phrase, so only 8 new phrases were written to file. -->
+
+<phrase>
+<original>currently available programs (listed by window title)</original>
+<translation>現在利用可能なプログラム (ウィンドウのタイトルで表示)</translation>
+</phrase>
+
+<phrase>
+<original>include window decorations</original>
+<translation>ウィンドウ装飾を含む</translation>
+</phrase>
+
+<phrase>
+<original>minimize PhotoDemon prior to capture</original>
+<translation>撮影前に PhotoDemon を最小化</translation>
+</phrase>
+
+<phrase>
+<original>screenshot source</original>
+<translation>スクリーンショット ソース</translation>
+</phrase>
+
+<phrase>
+<original>Please select a window to capture.</original>
+<translation>キャプチャするウィンドウを選択してください。</translation>
+</phrase>
+
+<phrase>
+<original>Target window required</original>
+<translation>対象ウィンドウが必要</translation>
+</phrase>
+
+<phrase>
+<original>entire desktop</original>
+<translation>デスクトップ全体</translation>
+</phrase>
+
+<phrase>
+<original>specific program</original>
+<translation>特定のプログラム</translation>
+</phrase>
+
+<phrase>
+<original>This program is currently minimized.  Restore it to normal size for best results.</original>
+<translation>このプログラムは現在最小化されています。  最良の結果を得るためには、通常のサイズに戻してください。</translation>
+</phrase>
+
+<phrase>
+<original>Some programs (including Windows Store apps) do not allow direct screen captures.  If an application preview appears as a black square, you will need to take a full desktop screenshot, then manually crop the desired window region.</original>
+<translation>一部のプログラム (Windowsストアアプリを含む)では、画面を直接キャプチャすることができません。  アプリケーションのプレビューが黒い四角で表示される場合は、デスクトップ全体のスクリーンショットを撮影し、必要なウィンドウ領域を手動でトリミングする必要があります。</translation>
+</phrase>
+
+<phrase>
+<original>Unfortunately, that program has exited.</original>
+<translation>残念ながら、そのプログラムは終了してしまった。</translation>
+</phrase>
+
+<phrase>
+<original>Please select another one.</original>
+<translation>他をお選びください。</translation>
+</phrase>
+
+<!-- File_Import_ScreenCapture.frm contains 22 phrases. 10 were duplicates of existing phrases, so only 12 new phrases were written to file. -->
+
+<phrase>
+<original>transparent</original>
+<translation>透明</translation>
+</phrase>
+
+<phrase>
+<original>black</original>
+<translation>黒</translation>
+</phrase>
+
+<phrase>
+<original>white</original>
+<translation>白</translation>
+</phrase>
+
+<phrase>
+<original>custom color</original>
+<translation>カスタム カラー</translation>
+</phrase>
+
+<!-- File_New.frm contains 7 phrases. 3 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>copies</original>
+<translation>コピー</translation>
+</phrase>
+
+<phrase>
+<original>printer</original>
+<translation>プリンター</translation>
+</phrase>
+
+<phrase>
+<original>paper size</original>
+<translation>用紙サイズ</translation>
+</phrase>
+
+<phrase>
+<original>Sending image to printer</original>
+<translation>プリンタへの画像送信</translation>
+</phrase>
+
+<phrase>
+<original>Image printed successfully. (Note: depending on your printer, additional print confirmation screens may appear.)</original>
+<translation>画像が正常に印刷されました。(注: プリンタによっては、追加の印刷確認画面が表示される場合があります)</translation>
+</phrase>
+
+<phrase>
+<original>%1 was unable to print the image.  Please make sure that the specified printer (%2) is powered-on and ready for printing.</original>
+<translation>%1 は画像を印刷できませんでした。  指定されたプリンタ (%2) の電源が入っていて、印刷できる状態になっていることを確認してください。</translation>
+</phrase>
+
+<phrase>
+<original>draft</original>
+<translation>草案</translation>
+</phrase>
+
+<phrase>
+<original>portrait</original>
+<translation>ポートレート</translation>
+</phrase>
+
+<phrase>
+<original>landscape</original>
+<translation>風景</translation>
+</phrase>
+
+<!-- File_PrintXP.frm contains 18 phrases. 9 were duplicates of existing phrases, so only 9 new phrases were written to file. -->
+
+<phrase>
+<original>preview quality changes</original>
+<translation>プレビュー画質の変更</translation>
+</phrase>
+
+<phrase>
+<original>image quality</original>
+<translation>画質</translation>
+</phrase>
+
+<phrase>
+<original>low quality, small file</original>
+<translation>低品質、小さいファイル</translation>
+</phrase>
+
+<phrase>
+<original>high quality, large file</original>
+<translation>高画質、大きいファイル</translation>
+</phrase>
+
+<phrase>
+<original>AVIF compression is very computationally intensive.  On older or slower PCs, you may want to disable live previews.</original>
+<translation>AVIF 圧縮は非常に計算量が多くなります。  古く遅い PC では、ライブ プレビューを無効にするとよいでしょう。</translation>
+</phrase>
+
+<!-- File_Save_AVIF.frm contains 8 phrases. 3 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<phrase>
+<original>restrict palette size</original>
+<translation>パレット サイズの制限</translation>
+</phrase>
+
+<phrase>
+<original>unique colors</original>
+<translation>ユニーク カラー</translation>
+</phrase>
+
+<phrase>
+<original>color model</original>
+<translation>カラー モデル</translation>
+</phrase>
+
+<phrase>
+<original>use RLE compression</original>
+<translation>RLE 圧縮を使用</translation>
+</phrase>
+
+<phrase>
+<original>premultiply alpha</original>
+<translation>事前乗算アルファ</translation>
+</phrase>
+
+<phrase>
+<original>flip row order (top-down)</original>
+<translation>行のオーダーを反転 (上から下へ)</translation>
+</phrase>
+
+<phrase>
+<original>use legacy 15-bit encoding (X1-R5-G5-B5)</original>
+<translation>レガシー 15 ビット エンコーディングを使用 (X1-R5-G5-B5)</translation>
+</phrase>
+
+<phrase>
+<original>color + transparency</original>
+<translation>カラー + 透明度</translation>
+</phrase>
+
+<phrase>
+<original>color only</original>
+<translation>カラーのみ</translation>
+</phrase>
+
+<phrase>
+<original>32-bpp XRGB (X8-R8-G8-B8)</original>
+<translation>32-bpp XRGB (X8-R8-G8-B8)</translation>
+</phrase>
+
+<phrase>
+<original>24-bpp RGB (R8-G8-B8)</original>
+<translation>24-bpp RGB (R8-G8-B8)</translation>
+</phrase>
+
+<phrase>
+<original>16-bpp (R5-G6-B5)</original>
+<translation>16-bpp (R5-G6-B5)</translation>
+</phrase>
+
+<phrase>
+<original>8-bpp</original>
+<translation>8-bpp</translation>
+</phrase>
+
+<phrase>
+<original>4-bpp</original>
+<translation>4-bpp</translation>
+</phrase>
+
+<phrase>
+<original>1-bpp</original>
+<translation>1-bpp</translation>
+</phrase>
+
+<!-- File_Save_BMP.frm contains 24 phrases. 9 were duplicates of existing phrases, so only 15 new phrases were written to file. -->
+
+<phrase>
+<original>transparent color (right-click image to select)</original>
+<translation>透過色 (画像を右クリックして選択)</translation>
+</phrase>
+
+<phrase>
+<original>metadata</original>
+<translation>メタデータ</translation>
+</phrase>
+
+<phrase>
+<original>by cut-off</original>
+<translation>締め切り</translation>
+</phrase>
+
+<phrase>
+<original>by color</original>
+<translation>色別</translation>
+</phrase>
+
+<!-- File_Save_GIF.frm contains 20 phrases. 16 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>icon purpose</original>
+<translation>アイコン目的</translation>
+</phrase>
+
+<phrase>
+<original>32-bpp</original>
+<translation>32-bpp</translation>
+</phrase>
+
+<phrase>
+<original>24-bpp</original>
+<translation>24-bpp</translation>
+</phrase>
+
+<phrase>
+<original>app - Windows 10</original>
+<translation>アプリ - Windows 10</translation>
+</phrase>
+
+<phrase>
+<original>app - Windows Vista, 7, 8</original>
+<translation>アプリ - Windows Vista、7、8</translation>
+</phrase>
+
+<phrase>
+<original>app - Windows XP</original>
+<translation>アプリ - Windows XP</translation>
+</phrase>
+
+<phrase>
+<original>app - Windows 95, 98, ME</original>
+<translation>アプリ - Windows 95、98、ME</translation>
+</phrase>
+
+<phrase>
+<original>web - favicon</original>
+<translation>ウェブ - ファビコン</translation>
+</phrase>
+
+<phrase>
+<original>custom icon</original>
+<translation>カスタム アイコン</translation>
+</phrase>
+
+<phrase>
+<original>use original file settings</original>
+<translation>元のファイル設定を使用</translation>
+</phrase>
+
+<!-- File_Save_ICO.frm contains 18 phrases. 8 were duplicates of existing phrases, so only 10 new phrases were written to file. -->
+
+<phrase>
+<original>image compression ratio</original>
+<translation>画像圧縮率</translation>
+</phrase>
+
+<phrase>
+<original>Lossless (1:1)</original>
+<translation>ロスレス (1:1)</translation>
+</phrase>
+
+<phrase>
+<original>Low compression, good image quality (16:1)</original>
+<translation>低圧縮、高画質 (16:1)</translation>
+</phrase>
+
+<phrase>
+<original>Moderate compression, medium image quality (32:1)</original>
+<translation>中程度の圧縮、中程度の画質 (32:1)</translation>
+</phrase>
+
+<phrase>
+<original>High compression, poor image quality (64:1)</original>
+<translation>高圧縮、低画質 (64:1)</translation>
+</phrase>
+
+<phrase>
+<original>Super compression, very poor image quality (256:1)</original>
+<translation>超圧縮で画質が非常に悪い (256:1)</translation>
+</phrase>
+
+<phrase>
+<original>Custom ratio (X:1)</original>
+<translation>カスタム比率 (X:1)</translation>
+</phrase>
+
+<!-- File_Save_JP2.frm contains 15 phrases. 8 were duplicates of existing phrases, so only 7 new phrases were written to file. -->
+
+<phrase>
+<original>compression method</original>
+<translation>圧縮方式</translation>
+</phrase>
+
+<phrase>
+<original>chroma subsampling</original>
+<translation>クロマ サブサンプリング</translation>
+</phrase>
+
+<phrase>
+<original>perfect (99)</original>
+<translation>パーフェクト (99)</translation>
+</phrase>
+
+<phrase>
+<original>excellent (92)</original>
+<translation>優秀 (92)</translation>
+</phrase>
+
+<phrase>
+<original>good (80)</original>
+<translation>良い (80)</translation>
+</phrase>
+
+<phrase>
+<original>average (65)</original>
+<translation>平均 (65)</translation>
+</phrase>
+
+<phrase>
+<original>low (40)</original>
+<translation>低い (40)</translation>
+</phrase>
+
+<phrase>
+<original>custom quality</original>
+<translation>カスタム品質</translation>
+</phrase>
+
+<phrase>
+<original>baseline</original>
+<translation>ベースライン</translation>
+</phrase>
+
+<phrase>
+<original>optimized baseline</original>
+<translation>最適化ベースライン</translation>
+</phrase>
+
+<phrase>
+<original>progressive</original>
+<translation>プログレッシブ</translation>
+</phrase>
+
+<phrase>
+<original>low (default)</original>
+<translation>低い (既定)</translation>
+</phrase>
+
+<phrase>
+<original>color (24-bpp)</original>
+<translation>カラー (24bpp)</translation>
+</phrase>
+
+<phrase>
+<original>black and white (8-bpp)</original>
+<translation>モノクロ (8ppp)</translation>
+</phrase>
+
+<!-- File_Save_JPG.frm contains 29 phrases. 15 were duplicates of existing phrases, so only 14 new phrases were written to file. -->
+
+<phrase>
+<original>use progressive encoding</original>
+<translation>プログレッシブエンコーディングを使用</translation>
+</phrase>
+
+<phrase>
+<original>Lossless (100)</original>
+<translation>ロスレス (100)</translation>
+</phrase>
+
+<phrase>
+<original>Low compression, good image quality (80)</original>
+<translation>低圧縮、高画質 (80)</translation>
+</phrase>
+
+<phrase>
+<original>Moderate compression, medium image quality (60)</original>
+<translation>中程度の圧縮、中程度の画質 (60)</translation>
+</phrase>
+
+<phrase>
+<original>High compression, poor image quality (40)</original>
+<translation>高圧縮、画質が悪い (40)</translation>
+</phrase>
+
+<phrase>
+<original>Super compression, very poor image quality (20)</original>
+<translation>超圧縮、非常に画質が悪い (20)</translation>
+</phrase>
+
+<!-- File_Save_JXR.frm contains 16 phrases. 10 were duplicates of existing phrases, so only 6 new phrases were written to file. -->
+
+<phrase>
+<original>change file extension to match color model</original>
+<translation>ファイル拡張子をカラーモデルに合わせる</translation>
+</phrase>
+
+<phrase>
+<original>format</original>
+<translation>フォーマット</translation>
+</phrase>
+
+<phrase>
+<original>floating-point</original>
+<translation>浮動小数点</translation>
+</phrase>
+
+<phrase>
+<original>binary</original>
+<translation>バイナリ</translation>
+</phrase>
+
+<phrase>
+<original>ASCII</original>
+<translation>アスキー</translation>
+</phrase>
+
+<!-- File_Save_Pixmap.frm contains 18 phrases. 13 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<phrase>
+<original>basic settings</original>
+<translation>基本設定</translation>
+</phrase>
+
+<phrase>
+<original>metadata settings</original>
+<translation>メタデータ設定</translation>
+</phrase>
+
+<phrase>
+<original>compression optimization</original>
+<translation>圧縮最適化</translation>
+</phrase>
+
+<phrase>
+<original>fast, larger file</original>
+<translation>高速、大容量ファイル</translation>
+</phrase>
+
+<phrase>
+<original>embed background color (bKGD chunk)</original>
+<translation>埋め込み背景色 (bKGDチャンク)</translation>
+</phrase>
+
+<phrase>
+<original>slow, smaller file</original>
+<translation>ファイルサイズが小さい</translation>
+</phrase>
+
+<phrase>
+<original>optimize: fast filters</original>
+<translation>最適化: 高速フィルター</translation>
+</phrase>
+
+<phrase>
+<original>optimize: all filters</original>
+<translation>最適化: すべてのフィルター</translation>
+</phrase>
+
+<phrase>
+<original>single filter: none</original>
+<translation>シングル フィルター: なし</translation>
+</phrase>
+
+<phrase>
+<original>single filter: sub</original>
+<translation>シングル フィルター: サブ</translation>
+</phrase>
+
+<phrase>
+<original>single filter: up</original>
+<translation>シングル フィルター: 上</translation>
+</phrase>
+
+<phrase>
+<original>single filter: average</original>
+<translation>シングル フィルター: 平均</translation>
+</phrase>
+
+<phrase>
+<original>single filter: paeth</original>
+<translation>シングル フィルター: ペース</translation>
+</phrase>
+
+<phrase>
+<original>PNG files support different compression strategies (called "filters").  Smart filter selection produces better compression.  Use the automatic setting to have PhotoDemon test multiple strategies, and automatically select the one that produces the best compression.</original>
+<translation>PNG ファイルは、さまざまな圧縮方式 (「フィルタ」と呼ばれる) をサポートしています。  スマートなフィルタ選択は、より良い圧縮を生成します。  自動設定を使用して、PhotoDemon が複数の方式をテストし、自動的に最良の圧縮を生成するものを選択します。</translation>
+</phrase>
+
+<!-- File_Save_PNG.frm contains 22 phrases. 8 were duplicates of existing phrases, so only 14 new phrases were written to file. -->
+
+<phrase>
+<original>maximize compatibility</original>
+<translation>最大限の互換性</translation>
+</phrase>
+
+<!-- File_Save_PSD.frm contains 11 phrases. 10 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>target version</original>
+<translation>対象バージョン</translation>
+</phrase>
+
+<!-- File_Save_PSP.frm contains 6 phrases. 5 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>color compression</original>
+<translation>色圧縮</translation>
+</phrase>
+
+<phrase>
+<original>monochrome compression</original>
+<translation>モノクロ圧縮</translation>
+</phrase>
+
+<phrase>
+<original>page format</original>
+<translation>ページ フォーマット</translation>
+</phrase>
+
+<phrase>
+<original>single page (composited image)</original>
+<translation>単ページ (合成画像)</translation>
+</phrase>
+
+<phrase>
+<original>multipage (one page per layer)</original>
+<translation>マルチ ページ (レイヤーごとに 1 ページ)</translation>
+</phrase>
+
+<!-- File_Save_TIFF.frm contains 16 phrases. 11 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<phrase>
+<original>image type</original>
+<translation>画像タイプ</translation>
+</phrase>
+
+<phrase>
+<original>generic</original>
+<translation>一般</translation>
+</phrase>
+
+<phrase>
+<original>indoor photo</original>
+<translation>室内写真</translation>
+</phrase>
+
+<phrase>
+<original>outdoor photo</original>
+<translation>屋外写真</translation>
+</phrase>
+
+<phrase>
+<original>chart</original>
+<translation>チャート</translation>
+</phrase>
+
+<phrase>
+<original>drawing (or other artwork)</original>
+<translation>デッサン (およびその他のアートワーク)</translation>
+</phrase>
+
+<phrase>
+<original>icon</original>
+<translation>アイコン</translation>
+</phrase>
+
+<!-- File_Save_WebP.frm contains 18 phrases. 11 were duplicates of existing phrases, so only 7 new phrases were written to file. -->
+
+<phrase>
+<original>About PhotoDemon</original>
+<translation>PhotoDemon について</translation>
+</phrase>
+
+<phrase>
+<original>the fast, free, portable photo editor</original>
+<translation>高速で、無料で、ポータブルなフォト エディタ</translation>
+</phrase>
+
+<phrase>
+<original>Participate in development, design, or translation work</original>
+<translation>開発、デザイン、翻訳業務への参加</translation>
+</phrase>
+
+<phrase>
+<original>Download program source code</original>
+<translation>プログラムのソース コードをダウンロード</translation>
+</phrase>
+
+<phrase>
+<original>Review program and plugin licenses</original>
+<translation>プログラムとプラグインのライセンスを確認</translation>
+</phrase>
+
+<phrase>
+<original>Latest news</original>
+<translation>最新ニュース</translation>
+</phrase>
+
+<phrase>
+<original>Contributors</original>
+<translation>貢献者</translation>
+</phrase>
+
+<phrase>
+<original>Patrons</original>
+<translation>パトロン</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon is Copyright %1 2000-%2 by Tanner Helland and Contributors</original>
+<translation>PhotoDemon の著作権は、%1 2000-%2 Tanner Hellandおよびコントリビューターに帰属します。</translation>
+</phrase>
+
+<phrase>
+<original>Donate to PhotoDemon development</original>
+<translation>PhotoDemon の開発に寄付</translation>
+</phrase>
+
+<phrase>
+<original>SUPER PATRONS</original>
+<translation>スーパー パトロン</translation>
+</phrase>
+
+<phrase>
+<original>PATRONS</original>
+<translation>パトロン</translation>
+</phrase>
+
+<phrase>
+<original>Thank you to our wonderful Patreon supporters!</original>
+<translation>素晴らしいパトロン サポーターに感謝します!</translation>
+</phrase>
+
+<phrase>
+<original>(You can become a patron, too!  Click here to learn more.)</original>
+<translation>(あなたもパトロンになれます! 詳しくはこちらをクリック)</translation>
+</phrase>
+
+<!-- Help_About.frm contains 23 phrases. 9 were duplicates of existing phrases, so only 14 new phrases were written to file. -->
+
+<phrase>
+<original>animation enabled for this image</original>
+<translation>この画像のアニメーションを有効</translation>
+</phrase>
+
+<!-- Image_Animation.frm contains 28 phrases. 27 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>anchor position</original>
+<translation>アンカーの位置</translation>
+</phrase>
+
+<!-- Image_CanvasSize.frm contains 4 phrases. 3 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>Compare images</original>
+<translation>画像を比較</translation>
+</phrase>
+
+<phrase>
+<original>resize images as necessary</original>
+<translation>必要に応じて画像をリサイズ</translation>
+</phrase>
+
+<phrase>
+<original>base image and layer</original>
+<translation>ベース画像とレイヤー</translation>
+</phrase>
+
+<phrase>
+<original>comparison image and layer</original>
+<translation>比較画像とレイヤー</translation>
+</phrase>
+
+<phrase>
+<original>compare using Lab color space</original>
+<translation>Labカラースペースを使った比較</translation>
+</phrase>
+
+<phrase>
+<original>generate difference map as a new layer</original>
+<translation>差分マップを新規レイヤーとして生成</translation>
+</phrase>
+
+<phrase>
+<original>difference between %1 and %2</original>
+<translation>%1 と %2 の差</translation>
+</phrase>
+
+<phrase>
+<original>infinite</original>
+<translation>無限</translation>
+</phrase>
+
+<phrase>
+<original>Peak signal-to-noise ratio (PSNR) between these images</original>
+<translation>これらの画像間のピーク信号対雑音比 (PSNR)</translation>
+</phrase>
+
+<phrase>
+<original>L*</original>
+<translation>L*</translation>
+</phrase>
+
+<phrase>
+<original>a*</original>
+<translation>a*</translation>
+</phrase>
+
+<phrase>
+<original>b*</original>
+<translation>b*</translation>
+</phrase>
+
+<phrase>
+<original>These images are identical.</original>
+<translation>これらの画像は同一です。</translation>
+</phrase>
+
+<phrase>
+<original>As a rough estimate, these images are %1% similar.</original>
+<translation>大まかに見積もって、これらの画像は %1% 似ています。</translation>
+</phrase>
+
+<phrase>
+<original>Image comparison</original>
+<translation>画像比較</translation>
+</phrase>
+
+<!-- Image_Compare.frm contains 29 phrases. 14 were duplicates of existing phrases, so only 15 new phrases were written to file. -->
+
+<phrase>
+<original>Note: this operation will flatten the image before resizing it.</original>
+<translation>注意: この操作は、リサイズする前に画像を統合します。</translation>
+</phrase>
+
+<phrase>
+<original>Initializing content-aware resize engine</original>
+<translation>コンテンツ認識リサイズ エンジンの初期化</translation>
+</phrase>
+
+<phrase>
+<original>Applying content-aware resize</original>
+<translation>コンテンツに応じたリサイズの適用</translation>
+</phrase>
+
+<!-- Image_ContentAwareResize.frm contains 12 phrases. 9 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>Create color lookup table (LUT)</original>
+<translation>カラー ルックアップ テーブル (LUT) の作成</translation>
+</phrase>
+
+<phrase>
+<original>add this to the "Adjustments > Color > Color lookup" tool</original>
+<translation>[調整] > [カラー] > [カラー ルックアップ]ツールに追加</translation>
+</phrase>
+
+<phrase>
+<original>modified image and layer</original>
+<translation>修正画像とレイヤー</translation>
+</phrase>
+
+<!-- Image_CreateLUT.frm contains 20 phrases. 17 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>tools</original>
+<translation>用具</translation>
+</phrase>
+
+<phrase>
+<original>metadata groups in this image</original>
+<translation>この画像のメタデータ グループ</translation>
+</phrase>
+
+<phrase>
+<original>tags in this category</original>
+<translation>このカテゴリのタグ</translation>
+</phrase>
+
+<phrase>
+<original>tag names</original>
+<translation>タグ名</translation>
+</phrase>
+
+<phrase>
+<original>tag values</original>
+<translation>タグの値</translation>
+</phrase>
+
+<phrase>
+<original>Generate full metadata report (HTML)</original>
+<translation>フル メタデータ レポート (HTML) の作成</translation>
+</phrase>
+
+<phrase>
+<original>visit the ExifTool homepage</original>
+<translation>ExifTool のホームページへ</translation>
+</phrase>
+
+<phrase>
+<original>Remove tags that might contain personal information</original>
+<translation>個人情報を含む可能性のあるタグを削除</translation>
+</phrase>
+
+<phrase>
+<original>%1 groups in this image</original>
+<translation>この画像に %1 個のグループ</translation>
+</phrase>
+
+<phrase>
+<original>technical</original>
+<translation>テクニカル</translation>
+</phrase>
+
+<phrase>
+<original>edit tags</original>
+<translation>編集タグ</translation>
+</phrase>
+
+<phrase>
+<original>editor options</original>
+<translation>エディタオプション</translation>
+</phrase>
+
+<phrase>
+<original>Mark this tag for removal</original>
+<translation>このタグに削除マークを付ける</translation>
+</phrase>
+
+<phrase>
+<original>Copy this tag to the clipboard</original>
+<translation>このタグをクリップボードにコピー</translation>
+</phrase>
+
+<phrase>
+<original>Reset tag to its original value</original>
+<translation>タグを元の値に戻す</translation>
+</phrase>
+
+<phrase>
+<original>Mark this entire group for removal</original>
+<translation>このグループ全体に削除マークを付ける</translation>
+</phrase>
+
+<phrase>
+<original>Copy all tags in this group to the clipboard</original>
+<translation>このグループのすべてのタグをクリップボードにコピー</translation>
+</phrase>
+
+<phrase>
+<original>Reset entire group to its original values</original>
+<translation>グループ全体を元の値に戻す</translation>
+</phrase>
+
+<phrase>
+<original>Metadata support is provided by the open-source ExifTool library.</original>
+<translation>メタデータのサポートは、オープンソースの ExifTool ライブラリによって提供されます。</translation>
+</phrase>
+
+<phrase>
+<original>1 tag in this category</original>
+<translation>このカテゴリに 1 個のタグ</translation>
+</phrase>
+
+<phrase>
+<original>%1 tags in this category</original>
+<translation>このカテゴリに %1 個のタグ</translation>
+</phrase>
+
+<phrase>
+<original>no tags in this category</original>
+<translation>このカテゴリのタグはありません</translation>
+</phrase>
+
+<phrase>
+<original>"System" tags are provided by the operating system.  They are not embedded as traditional metadata.</original>
+<translation>「システム」タグは、オペレーティング システムによって提供されます。  従来のメタデータとしては埋め込まれていなません。</translation>
+</phrase>
+
+<phrase>
+<original>"File" tags are required by this image format.  They are not embedded as traditional metadata.</original>
+<translation>「ファイル "タグは、この画像フォーマットでは必須です。  従来のメタデータとしては埋め込まれていません。</translation>
+</phrase>
+
+<phrase>
+<original>ICC profiles are handled automatically by PhotoDemon.  They are not embedded as traditional metadata.</original>
+<translation>ICC プロファイルは、PhotoDemonによって自動的に処理されます。  それらは従来のメタデータとして埋め込まれません。</translation>
+</phrase>
+
+<phrase>
+<original>"Inferred" tags are hypothetical values inferred from other metadata.  They are not embedded as traditional metadata.</original>
+<translation>"Inferred" タグは、他のメタデータから推測される仮説的な値です。  従来のメタデータとして埋め込まれることはありません。</translation>
+</phrase>
+
+<phrase>
+<original>tag restrictions</original>
+<translation>タグ制限</translation>
+</phrase>
+
+<phrase>
+<original>This is a protected tag.  Edits are allowed, but they may be overwritten to produce a valid image file.</original>
+<translation>これは保護されたタグです。  編集は許可されていますが、有効な画像ファイルを作成するために上書きされることがあります。</translation>
+</phrase>
+
+<phrase>
+<original>This tag is restricted.  It cannot be edited, and removal requests will be ignored if they result in an invalid file.</original>
+<translation>このタグは制限されています。  このタグは編集することができず、削除要求が無効なファイルになった場合は無視されます。</translation>
+</phrase>
+
+<phrase>
+<original>integers only [%1 to %2]</original>
+<translation>整数のみ [%1 から %2]</translation>
+</phrase>
+
+<phrase>
+<original>integers only</original>
+<translation>整数のみ</translation>
+</phrase>
+
+<phrase>
+<original>integers >= 0</original>
+<translation>整数 >= 0</translation>
+</phrase>
+
+<phrase>
+<original>numbers only</original>
+<translation>数字のみ</translation>
+</phrase>
+
+<phrase>
+<original>numbers >= 0</original>
+<translation>数値 >= 0</translation>
+</phrase>
+
+<phrase>
+<original>file position marker</original>
+<translation>ファイル位置マーカー</translation>
+</phrase>
+
+<phrase>
+<original>binary data</original>
+<translation>バイナリデータ</translation>
+</phrase>
+
+<phrase>
+<original>digits</original>
+<translation>桁</translation>
+</phrase>
+
+<phrase>
+<original>dates only (YYYY:mm:dd HH:MM:SS[.ss][+/-HH:MM])</original>
+<translation>日付のみ (YYYY:mm:dd HH:MM:SS[.ss][+/-HH:MM])</translation>
+</phrase>
+
+<phrase>
+<original>true or false only</original>
+<translation>真または偽のみ</translation>
+</phrase>
+
+<phrase>
+<original>digits only</original>
+<translation>数字のみ</translation>
+</phrase>
+
+<phrase>
+<original>%1 characters max</original>
+<translation>最大 %1 文字</translation>
+</phrase>
+
+<phrase>
+<original>%1 bytes max</original>
+<translation>最大 %1 バイト</translation>
+</phrase>
+
+<phrase>
+<original>%1 numbers max</original>
+<translation>最大 %1</translation>
+</phrase>
+
+<phrase>
+<original>list of %1, one entry per line</original>
+<translation>%1 のリスト、1 行ごとに 1 つのエントリ</translation>
+</phrase>
+
+<!-- Image_Metadata.frm contains 116 phrases. 72 were duplicates of existing phrases, so only 44 new phrases were written to file. -->
+
+<phrase>
+<original>preview changes</original>
+<translation>プレビューの変更</translation>
+</phrase>
+
+<phrase>
+<original>optimize for speed</original>
+<translation>速度に最適化</translation>
+</phrase>
+
+<phrase>
+<original>when changing aspect ratio, fit image to new size by</original>
+<translation>アスペクト比を変更する場合は、次の方法で画像を新しいサイズに合わせる</translation>
+</phrase>
+
+<phrase>
+<original>resampling</original>
+<translation>リサンプリング</translation>
+</phrase>
+
+<phrase>
+<original>stretching to new size  (default)</original>
+<translation>新しいサイズに引き伸ばす (既定)</translation>
+</phrase>
+
+<phrase>
+<original>fitting inclusively, with transparent borders as necessary</original>
+<translation>必要に応じて透明な境界線を加え、サイズ内におさめる</translation>
+</phrase>
+
+<phrase>
+<original>fitting exclusively, and cropping as necessary</original>
+<translation>必要に応じてトリミングし、サイズいっぱいに合わせる</translation>
+</phrase>
+
+<phrase>
+<original>Some image resampling filters support approximate calculations.  These improve performance at a minor penalty to quality.</original>
+<translation>一部の画像リサンプリングフィルタは近似計算をサポートしています。  これらは、わずかな品質への影響と引き換えに、パフォーマンスを向上させます。</translation>
+</phrase>
+
+<phrase>
+<original>Resampling affects the quality of a resized image.  For a good summary of resampling techniques, visit the Image Resampling article on Wikipedia.</original>
+<translation>リサンプリングは、リサイズされた画像の品質に影響を与えます。  リサンプリング技術に関する優れた要約は、Wikipedia の画像リサンプリングの記事をご覧ください。</translation>
+</phrase>
+
+<phrase>
+<original>When changing an image's aspect ratio, undesirable stretching may occur.  PhotoDemon can avoid this by using empty borders or cropping instead.</original>
+<translation>画像のアスペクト比を変更する場合、望ましくない伸張が発生することがあります。  PhotoDemon は、余白またはトリミングを代わりに使用することにより、これを避けることができます。</translation>
+</phrase>
+
+<phrase>
+<original>Resizing image</original>
+<translation>画像のリサイズ</translation>
+</phrase>
+
+<phrase>
+<original>Resizing layer</original>
+<translation>レイヤーのサイズ変更</translation>
+</phrase>
+
+<!-- Image_Resize.frm contains 21 phrases. 9 were duplicates of existing phrases, so only 12 new phrases were written to file. -->
+
+<phrase>
+<original>border regions</original>
+<translation>境界線外の領域</translation>
+</phrase>
+
+<phrase>
+<original>Rotating layer</original>
+<translation>レイヤーを回転しています</translation>
+</phrase>
+
+<phrase>
+<original>Rotation complete.</original>
+<translation>回転しました。</translation>
+</phrase>
+
+<phrase>
+<original>enlarge to fit</original>
+<translation>合わせて拡大</translation>
+</phrase>
+
+<phrase>
+<original>fill with color</original>
+<translation>色で塗りつぶす</translation>
+</phrase>
+
+<phrase>
+<original>Rotate image</original>
+<translation>画像を回転</translation>
+</phrase>
+
+<phrase>
+<original>Rotate layer</original>
+<translation>レイヤーを回転</translation>
+</phrase>
+
+<!-- Image_Rotate.frm contains 21 phrases. 14 were duplicates of existing phrases, so only 7 new phrases were written to file. -->
+
+<phrase>
+<original>Straightening image</original>
+<translation>画像を補正</translation>
+</phrase>
+
+<phrase>
+<original>Straightening layer</original>
+<translation>補正レイヤー</translation>
+</phrase>
+
+<phrase>
+<original>Straighten complete.</original>
+<translation>傾き補正を完了しました。</translation>
+</phrase>
+
+<!-- Image_Straighten.frm contains 14 phrases. 11 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>make the new layer the active layer</original>
+<translation>新しいレイヤーをアクティブ レイヤーにする</translation>
+</phrase>
+
+<phrase>
+<original>default (above current layer)</original>
+<translation>既定 (現在のレイヤーの上)</translation>
+</phrase>
+
+<phrase>
+<original>below current layer</original>
+<translation>現在のレイヤーの下</translation>
+</phrase>
+
+<phrase>
+<original>top of layer stack</original>
+<translation>レイヤー スタックの最上層</translation>
+</phrase>
+
+<phrase>
+<original>bottom of layer stack</original>
+<translation>レイヤー スタックの最下層</translation>
+</phrase>
+
+<!-- Layer_Add_RasterLayer.frm contains 18 phrases. 13 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<phrase>
+<original>flatten behavior</original>
+<translation>フラットな動作</translation>
+</phrase>
+
+<phrase>
+<original>keep transparency</original>
+<translation>透過を保つ</translation>
+</phrase>
+
+<phrase>
+<original>remove transparency</original>
+<translation>透過を取り除く</translation>
+</phrase>
+
+<!-- Layer_Flatten.frm contains 7 phrases. 4 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<phrase>
+<original>after importing source images</original>
+<translation>ソース画像をインポートした後</translation>
+</phrase>
+
+<phrase>
+<original>canvas size</original>
+<translation>キャンバス サイズ</translation>
+</phrase>
+
+<phrase>
+<original>align imported layers</original>
+<translation>インポートしたレイヤーを揃える</translation>
+</phrase>
+
+<phrase>
+<original>if imported layer names match existing layer names</original>
+<translation>インポートしたレイヤー名が既存のレイヤー名と一致する場合</translation>
+</phrase>
+
+<phrase>
+<original>destination image</original>
+<translation>目的の画像</translation>
+</phrase>
+
+<phrase>
+<original>source image(s)</original>
+<translation>ソース画像</translation>
+</phrase>
+
+<phrase>
+<original>keep current size</original>
+<translation>現在のサイズを維持</translation>
+</phrase>
+
+<phrase>
+<original>resize to fit imported layers</original>
+<translation>インポートしたレイヤーに合わせてサイズを変更</translation>
+</phrase>
+
+<phrase>
+<original>replace existing layers with imported ones</original>
+<translation>既存のレイヤーをインポートしたレイヤーに置き換える</translation>
+</phrase>
+
+<phrase>
+<original>add duplicates as new layers</original>
+<translation>複製を新規レイヤーとして追加</translation>
+</phrase>
+
+<phrase>
+<original>leave images open</original>
+<translation>画像をオープンにしておく</translation>
+</phrase>
+
+<phrase>
+<original>close images normally (prompt for unsaved changes)</original>
+<translation>画像を普通に閉じる (未保存の変更はプロンプトを表示)</translation>
+</phrase>
+
+<phrase>
+<original>close images without prompting</original>
+<translation>プロンプトなしで画像を閉じる</translation>
+</phrase>
+
+<!-- Layer_Split_ImagesToLayers.frm contains 15 phrases. 2 were duplicates of existing phrases, so only 13 new phrases were written to file. -->
+
+<phrase>
+<original>Make color transparent</original>
+<translation>色を透過</translation>
+</phrase>
+
+<phrase>
+<original>erase threshold</original>
+<translation>消去しきい値</translation>
+</phrase>
+
+<phrase>
+<original>color to erase (right-click preview to select)</original>
+<translation>消去する色 (プレビューを右クリックで選択)</translation>
+</phrase>
+
+<phrase>
+<original>Adding new alpha channel to image</original>
+<translation>画像に新しいアルファ チャンネルを追加</translation>
+</phrase>
+
+<!-- Layer_Transparency_GreenScreen.frm contains 6 phrases. 2 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>Generate mask from luminance</original>
+<translation>輝度からマスクを生成</translation>
+</phrase>
+
+<phrase>
+<original>black is transparent</original>
+<translation>黒を透過</translation>
+</phrase>
+
+<phrase>
+<original>white is transparent</original>
+<translation>白を透過</translation>
+</phrase>
+
+<phrase>
+<original>gray is transparent</original>
+<translation>灰色を透過</translation>
+</phrase>
+
+<!-- Layer_Transparency_Luma.frm contains 6 phrases. 2 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
+
+<phrase>
+<original>Removing transparency</original>
+<translation>透過の除去</translation>
+</phrase>
+
+<!-- Layer_Transparency_RemoveTransparency.frm contains 5 phrases. 4 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>Converting alpha channel</original>
+<translation>アルファ チャンネルの変換</translation>
+</phrase>
+
+<!-- Layer_Transparency_Threshold.frm contains 7 phrases. 6 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<!-- Layerpanel_Colors.frm contains 2 phrases.  All were duplicates of existing phrases, so no new phrases were written to file. -->
+
+<phrase>
+<original>blend</original>
+<translation>ブレンド</translation>
+</phrase>
+
+<phrase>
+<original>Click: show the "New layer" dialog</original>
+<translation>クリック: "新規レイヤー "ダイアログを表示</translation>
+</phrase>
+
+<phrase>
+<original>Shift + Click: add a blank layer</original>
+<translation>Shift + クリック: 空白のレイヤーを追加</translation>
+</phrase>
+
+<phrase>
+<original>Add layer</original>
+<translation>レイヤーを追加</translation>
+</phrase>
+
+<phrase>
+<original>Click: delete this layer</original>
+<translation>クリック: このレイヤーを削除する</translation>
+</phrase>
+
+<phrase>
+<original>Click: move this layer up the layer stack</original>
+<translation>クリック: このレイヤーをレイヤー スタックの上に移動</translation>
+</phrase>
+
+<phrase>
+<original>Shift + Click: merge this layer with the layer above it</original>
+<translation>Shift + クリック: このレイヤーとその上のレイヤーを結合します</translation>
+</phrase>
+
+<phrase>
+<original>Move or merge layer up</original>
+<translation>レイヤーを上に移動またはマージする</translation>
+</phrase>
+
+<phrase>
+<original>Click: move this layer down the layer stack</original>
+<translation>クリック: このレイヤーをレイヤー スタックの下に移動</translation>
+</phrase>
+
+<phrase>
+<original>Shift + Click: merge this layer with the layer beneath it</original>
+<translation>Shift + クリック: このレイヤーとその下のレイヤーを統合する</translation>
+</phrase>
+
+<phrase>
+<original>Move or merge layer down</original>
+<translation>レイヤーを下に移動またはマージする</translation>
+</phrase>
+
+<phrase>
+<original>Click: add a duplicate of this layer</original>
+<translation>クリック: このレイヤーの複製を追加する</translation>
+</phrase>
+
+<phrase>
+<original>Duplicate layer</original>
+<translation>レイヤーを複製</translation>
+</phrase>
+
+<!-- Layerpanel_Layers.frm contains 22 phrases. 9 were duplicates of existing phrases, so only 13 new phrases were written to file. -->
+
+<phrase>
+<original>Selection options</original>
+<translation>選択オプション</translation>
+</phrase>
+
+<!-- Select_GenericModification.frm contains 21 phrases. 20 were duplicates of existing phrases, so only one new phrase was written to file. -->
+
+<phrase>
+<original>version %1</original>
+<translation>バージョン %1</translation>
+</phrase>
+
+<!-- Startup_Splash.frm contains 2 phrases.  One was a duplicate of an existing phrase, so only 1 new phrases were written to file. -->
+
+<phrase>
+<original>search</original>
+<translation>検索</translation>
+</phrase>
+
+<phrase>
+<original>overview</original>
+<translation>オーバービュー</translation>
+</phrase>
+
+<phrase>
+<original>layers</original>
+<translation>レイヤー</translation>
+</phrase>
+
+<!-- Toolbar_Layers.frm contains 5 phrases. 2 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
+
+<!-- Toolbar_ToolOptionsContainer.frm contains 1 phrase.  One was a duplicate of an existing phrase, so only 0 new phrases were written to file. -->
+
+<phrase>
+<original>file</original>
+<translation>ファイル</translation>
+</phrase>
+
+<phrase>
+<original>undo</original>
+<translation>元に戻す</translation>
+</phrase>
+
+<phrase>
+<original>layout</original>
+<translation>レイアウト</translation>
+</phrase>
+
+<phrase>
+<original>select</original>
+<translation>選択</translation>
+</phrase>
+
+<phrase>
+<original>paint</original>
+<translation>描画</translation>
+</phrase>
+
+<phrase>
+<original>macro recording in progress</original>
+<translation>マクロ記録中</translation>
+</phrase>
+
+<phrase>
+<original>File tools: create, load, and save image files</original>
+<translation>ファイルツール: 画像ファイルの作成、読み込み、保存</translation>
+</phrase>
+
+<phrase>
+<original>Undo/Redo tools: revert changes made to an image or layer</original>
+<translation>元に戻す/やり直しツール: 画像やレイヤーに加えられた変更を元に戻します</translation>
+</phrase>
+
+<phrase>
+<original>Layout tools: explore, zoom, move or measure an image or layer</original>
+<translation>レイアウトツール: 画像やレイヤーの探索、ズーム、移動、測定</translation>
+</phrase>
+
+<phrase>
+<original>Select tools: isolate parts of an image or layer for further editing</original>
+<translation>選択ツール: 画像やレイヤーの一部を分離して、さらに編集できます</translation>
+</phrase>
+
+<phrase>
+<original>Text tools: create and edit text layers</original>
+<translation>テキストツール: テキスト レイヤーの作成と編集</translation>
+</phrase>
+
+<phrase>
+<original>Paint tools: use a mouse, touchpad, or pen tablet to apply brushstrokes to an image or layer</original>
+<translation>ペイントツール: マウス、タッチパッド、ペンタブレットを使用して、画像やレイヤーにブラシストロークを適用します</translation>
+</phrase>
+
+<phrase>
+<original>This option will create a blank image.  Other ways to create new images can be found in the File -> Import menu.</original>
+<translation>このオプションは空白の画像を作成します。  新規画像を作成する他の方法は、[ファイル] -> [インポート] メニューにあります。</translation>
+</phrase>
+
+<phrase>
+<original>New Image</original>
+<translation>新規画像</translation>
+</phrase>
+
+<phrase>
+<original>Another way to open images is dragging them from your desktop or Windows Explorer and dropping them onto PhotoDemon.</original>
+<translation>画像を開くもう一つの方法は、デスクトップまたは Windows エクスプローラから PhotoDemon にドラッグ &amp; ドロップすることです。</translation>
+</phrase>
+
+<phrase>
+<original>Open one or more images for editing</original>
+<translation>編集用に 1 つまたは複数の画像を開く</translation>
+</phrase>
+
+<phrase>
+<original>If the current image has not been saved, you will receive a prompt to save it before it closes.</original>
+<translation>現在の画像が保存されていない場合、閉じる前に保存を促すプロンプトが表示されます。</translation>
+</phrase>
+
+<phrase>
+<original>Close the current image</original>
+<translation>現在の画像を閉じる</translation>
+</phrase>
+
+<phrase>
+<original>Because you have turned off save prompts (via Edit -> Preferences), you WILL NOT receive a prompt to save this image before it closes.</original>
+<translation>保存プロンプトをオフにしている ([ツール] -> [オプション] で設定) ため、この画像を閉じる前に保存を促すプロンプトは表示されません。</translation>
+</phrase>
+
+<phrase>
+<original>WARNING: this will overwrite the current image file.  To save to a different file, use the "Save As" button.</original>
+<translation>警告: これは現在の画像ファイルを上書きします。  別のファイルに保存するには、"名前を付けて保存 "ボタンを押してください。</translation>
+</phrase>
+
+<phrase>
+<original>Save image in current format</original>
+<translation>現在のフォーマットで画像を保存</translation>
+</phrase>
+
+<phrase>
+<original>You have specified "safe" save mode, which means that each save will create a new file with an auto-incremented filename.</original>
+<translation>"セーフ" 保存モードが指定されているため、保存のたびに自動でファイル名の数字を 1 ずつ増やした、新しいファイルが作成されます。</translation>
+</phrase>
+
+<phrase>
+<original>Use this to quickly save a lossless copy of the current image.  The lossless copy will be saved in PDI format, in the image's current folder, using the current filename (plus an auto-incremented number, as necessary).</original>
+<translation>この機能を使うと、現在の画像のロスレス コピーをすばやく保存できます。  ロスレス コピーは PDI 形式で、画像の現在のフォルダに、現在のファイル名 (必要に応じて自動インクリメントされる番号も追加されます)を使って保存されます。</translation>
+</phrase>
+
+<phrase>
+<original>Save lossless copy</original>
+<translation>ロスレス コピーを保存</translation>
+</phrase>
+
+<phrase>
+<original>The Save As command always raises a dialog, so you can specify a new file name, folder, and/or image format for the current image.</original>
+<translation>[名前を付けて保存] コマンドは常にダイアログを表示するので、現在の画像の新しいファイル名、フォルダー、画像形式を指定できます。</translation>
+</phrase>
+
+<phrase>
+<original>Save As (export to new format or filename)</original>
+<translation>名前を付けて保存 (新しいフォーマットまたはファイル名にエクスポートする)</translation>
+</phrase>
+
+<phrase>
+<original>Hand (click-and-drag image scrolling)</original>
+<translation>ハンド (クリック &amp; ドラッグで画像スクロール)</translation>
+</phrase>
+
+<phrase>
+<original>Shortcut key: %1</original>
+<translation>ショートカット キー: %1</translation>
+</phrase>
+
+<phrase>
+<original>Zoom</original>
+<translation>ズーム</translation>
+</phrase>
+
+<phrase>
+<original>Move and resize image layers</original>
+<translation>画像レイヤーの移動とサイズ変更</translation>
+</phrase>
+
+<phrase>
+<original>Select colors from the image</original>
+<translation>画像から色を選択</translation>
+</phrase>
+
+<phrase>
+<original>Measure angles and distances</original>
+<translation>角度と距離を測る</translation>
+</phrase>
+
+<phrase>
+<original>Rectangular Selection</original>
+<translation>長方形の選択</translation>
+</phrase>
+
+<phrase>
+<original>Elliptical (Oval) Selection</original>
+<translation>楕円 (オーバル) 選択</translation>
+</phrase>
+
+<phrase>
+<original>Polygon Selection</original>
+<translation>ポリゴン選択</translation>
+</phrase>
+
+<phrase>
+<original>Lasso (Freehand) Selection</original>
+<translation>投げ縄 (フリーハンド) 選択</translation>
+</phrase>
+
+<phrase>
+<original>Magic Wand Selection</original>
+<translation>マジック ワンドで選択</translation>
+</phrase>
+
+<phrase>
+<original>Basic Text</original>
+<translation>基本テキスト</translation>
+</phrase>
+
+<phrase>
+<original>Advanced Text</original>
+<translation>高度なテキスト</translation>
+</phrase>
+
+<phrase>
+<original>Pencil (hard-tipped brush)</original>
+<translation>鉛筆 (硬筆)</translation>
+</phrase>
+
+<phrase>
+<original>Paintbrush (soft-tipped brush)</original>
+<translation>絵筆 (穂先の柔らかいもの)</translation>
+</phrase>
+
+<phrase>
+<original>Eraser</original>
+<translation>消しゴム</translation>
+</phrase>
+
+<phrase>
+<original>Paint bucket (fill with color)</original>
+<translation>ペンキ用バケツ (色を入れる)</translation>
+</phrase>
+
+<phrase>
+<original>Gradient</original>
+<translation>グラデーション</translation>
+</phrase>
+
+<phrase>
+<original>Hand tool</original>
+<translation>ハンドツール</translation>
+</phrase>
+
+<phrase>
+<original>Zoom tool</original>
+<translation>ズームツール</translation>
+</phrase>
+
+<phrase>
+<original>Move tool</original>
+<translation>移動ツール</translation>
+</phrase>
+
+<phrase>
+<original>Color selector tool</original>
+<translation>色選択ツール</translation>
+</phrase>
+
+<phrase>
+<original>Measure tool</original>
+<translation>測定ツール</translation>
+</phrase>
+
+<phrase>
+<original>Rectangle selection tool</original>
+<translation>矩形選択ツール</translation>
+</phrase>
+
+<phrase>
+<original>Ellipse selection tool</original>
+<translation>楕円選択ツール</translation>
+</phrase>
+
+<phrase>
+<original>Polygon selection tool</original>
+<translation>ポリゴン選択ツール</translation>
+</phrase>
+
+<phrase>
+<original>Lasso selection tool</original>
+<translation>投げ縄選択ツール</translation>
+</phrase>
+
+<phrase>
+<original>Magic wand selection tool</original>
+<translation>マジック ワンド選択ツール</translation>
+</phrase>
+
+<phrase>
+<original>Basic text tool</original>
+<translation>基本テキストツール</translation>
+</phrase>
+
+<phrase>
+<original>Advanced text tool</original>
+<translation>高度なテキストツール</translation>
+</phrase>
+
+<phrase>
+<original>Pencil tool</original>
+<translation>鉛筆ツール</translation>
+</phrase>
+
+<phrase>
+<original>Paintbrush tool</original>
+<translation>ペイントブラシツール</translation>
+</phrase>
+
+<phrase>
+<original>Erase tool</original>
+<translation>消去ツール</translation>
+</phrase>
+
+<phrase>
+<original>Clone stamp tool</original>
+<translation>クローンスタンプツール</translation>
+</phrase>
+
+<phrase>
+<original>Paint bucket tool</original>
+<translation>ペイントバケツツール</translation>
+</phrase>
+
+<!-- Toolbar_ToolSelect.frm contains 102 phrases. 41 were duplicates of existing phrases, so only 61 new phrases were written to file. -->
+
+<phrase>
+<original>pattern mode</original>
+<translation>パターンモード</translation>
+</phrase>
+
+<phrase>
+<original>aligned</original>
+<translation>整列</translation>
+</phrase>
+
+<phrase>
+<original>flow</original>
+<translation>強さ</translation>
+</phrase>
+
+<phrase>
+<original>spacing</original>
+<translation>間隔</translation>
+</phrase>
+
+<phrase>
+<original>hardness</original>
+<translation>硬さ</translation>
+</phrase>
+
+<phrase>
+<original>source settings</original>
+<translation>ソース設定</translation>
+</phrase>
+
+<phrase>
+<original>layer</original>
+<translation>レイヤー</translation>
+</phrase>
+
+<phrase>
+<original>tile</original>
+<translation>タイル</translation>
+</phrase>
+
+<phrase>
+<original>tile + flip horizontal</original>
+<translation>タイル + 左右反転</translation>
+</phrase>
+
+<phrase>
+<original>tile + flip vertical</original>
+<translation>タイル + 上下反転</translation>
+</phrase>
+
+<phrase>
+<original>tile + flip both</original>
+<translation>タイル + 上下左右反転</translation>
+</phrase>
+
+<!-- Toolpanel_Clone.frm contains 20 phrases. 9 were duplicates of existing phrases, so only 11 new phrases were written to file. -->
+
+<phrase>
+<original>after clicking</original>
+<translation>クリックしたあと</translation>
+</phrase>
+
+<phrase>
+<original>return to previous tool</original>
+<translation>前のツールに戻る</translation>
+</phrase>
+
+<phrase>
+<original>RGB %</original>
+<translation>RGB %</translation>
+</phrase>
+
+<phrase>
+<original>HSV</original>
+<translation>HSV</translation>
+</phrase>
+
+<phrase>
+<original>n/a</original>
+<translation>なし</translation>
+</phrase>
+
+<!-- Toolpanel_ColorPicker.frm contains 45 phrases. 40 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<!-- Toolpanel_Eraser.frm contains 7 phrases.  All were duplicates of existing phrases, so no new phrases were written to file. -->
+
+<phrase>
+<original>fill source</original>
+<translation>塗りのソース</translation>
+</phrase>
+
+<phrase>
+<original>brush style</original>
+<translation>筆記体</translation>
+</phrase>
+
+<phrase>
+<original>tolerance</original>
+<translation>許容値</translation>
+</phrase>
+
+<phrase>
+<original>compare pixels by</original>
+<translation>ピクセル単位で比較</translation>
+</phrase>
+
+<phrase>
+<original>fill area</original>
+<translation>塗りの領域</translation>
+</phrase>
+
+<phrase>
+<original>current color</original>
+<translation>現在の色</translation>
+</phrase>
+
+<phrase>
+<original>custom brush</original>
+<translation>カスタム ブラシ</translation>
+</phrase>
+
+<phrase>
+<original>contiguous</original>
+<translation>連続的</translation>
+</phrase>
+
+<phrase>
+<original>Fills support many different styles.  Click to switch between solid color, pattern, and gradient styles.</original>
+<translation>塗りつぶしは様々なスタイルをサポートします。  クリックすると、無地、パターン、グラデーションのスタイルに切り替わります。</translation>
+</phrase>
+
+<phrase>
+<original>Tolerance controls how similar two pixels must be before spreading the fill between them.</original>
+<translation>トレランスは、2 つのピクセルの間に塗りつぶしを広げる前に、2 つのピクセルがどの程度似ていなければならないかを制御します。</translation>
+</phrase>
+
+<phrase>
+<original>Normally, fill operations analyze the entire image.  You can also analyze just the active layer.</original>
+<translation>通常、塗りつぶし操作は画像全体を分析します。  アクティブ レイヤーだけを分析することもできます。</translation>
+</phrase>
+
+<phrase>
+<original>Normally, fills spread out from a target pixel, adding neighboring pixels as it goes.  You can alternatively set it to analyze the entire image, without regard for continuity.</original>
+<translation>通常、塗りつぶしは対象のピクセルから広がっていき、隣接するピクセルを追加しながら進みます。  連続性を無視して画像全体を分析するように設定することもできます。</translation>
+</phrase>
+
+<phrase>
+<original>This option controls how pixels are analyzed when adding them to the fill.</original>
+<translation>このオプションは、塗りつぶしにピクセルを追加する際の解析方法を制御します。</translation>
+</phrase>
+
+<!-- Toolpanel_Fill.frm contains 21 phrases. 8 were duplicates of existing phrases, so only 13 new phrases were written to file. -->
+
+<phrase>
+<original>center offset</original>
+<translation>中心のオフセット</translation>
+</phrase>
+
+<phrase>
+<original>linear</original>
+<translation>線形</translation>
+</phrase>
+
+<phrase>
+<original>radial</original>
+<translation>円形</translation>
+</phrase>
+
+<phrase>
+<original>spherical</original>
+<translation>球体</translation>
+</phrase>
+
+<phrase>
+<original>conical</original>
+<translation>円錐</translation>
+</phrase>
+
+<phrase>
+<original>spiral</original>
+<translation>渦巻き</translation>
+</phrase>
+
+<!-- Toolpanel_Gradient.frm contains 19 phrases. 13 were duplicates of existing phrases, so only 6 new phrases were written to file. -->
+
+<phrase>
+<original>modify measurement</original>
+<translation>測定値を修正</translation>
+</phrase>
+
+<phrase>
+<original>share measurements between images</original>
+<translation>画像間で測定値を共有</translation>
+</phrase>
+
+<phrase>
+<original>swap points</original>
+<translation>ポイントを入れ替え</translation>
+</phrase>
+
+<phrase>
+<original>rotate 90</original>
+<translation>90度回転</translation>
+</phrase>
+
+<phrase>
+<original>clear points</original>
+<translation>ポイントをクリア</translation>
+</phrase>
+
+<phrase>
+<original>straighten image</original>
+<translation>画像の傾き補正</translation>
+</phrase>
+
+<phrase>
+<original>straighten layer</original>
+<translation>レイヤーの傾き補正</translation>
+</phrase>
+
+<phrase>
+<original>use measurement to</original>
+<translation>計測を使用</translation>
+</phrase>
+
+<!-- Toolpanel_Measure.frm contains 19 phrases. 11 were duplicates of existing phrases, so only 8 new phrases were written to file. -->
+
+<phrase>
+<original>size (w, h)</original>
+<translation>サイズ (幅, 高さ)</translation>
+</phrase>
+
+<phrase>
+<original>lock aspect ratio</original>
+<translation>アスペクト比を固定</translation>
+</phrase>
+
+<phrase>
+<original>transform quality</original>
+<translation>変形の品質</translation>
+</phrase>
+
+<phrase>
+<original>ignore transparent pixels</original>
+<translation>透明ピクセルを無視</translation>
+</phrase>
+
+<phrase>
+<original>show layer borders</original>
+<translation>レイヤーの境界線を表示</translation>
+</phrase>
+
+<phrase>
+<original>show resize nodes</original>
+<translation>リサイズ ノードを表示</translation>
+</phrase>
+
+<phrase>
+<original>display options</original>
+<translation>表示オプション</translation>
+</phrase>
+
+<phrase>
+<original>show rotate nodes</original>
+<translation>ノードを回転させる</translation>
+</phrase>
+
+<phrase>
+<original>make transforms permanent</original>
+<translation>変形を永続化</translation>
+</phrase>
+
+<phrase>
+<original>sample selections from</original>
+<translation>選択の対象</translation>
+</phrase>
+
+<phrase>
+<original>default selection behavior</original>
+<translation>既定の選択動作</translation>
+</phrase>
+
+<phrase>
+<original>position (x, y)</original>
+<translation>位置</translation>
+</phrase>
+
+<phrase>
+<original>shear (x, y)</original>
+<translation>せん断</translation>
+</phrase>
+
+<phrase>
+<original>auto select layer</original>
+<translation>レイヤーの自動選択</translation>
+</phrase>
+
+<phrase>
+<original>Make layer changes permanent</original>
+<translation>レイヤーの変更を恒久的に</translation>
+</phrase>
+
+<phrase>
+<original>copy</original>
+<translation>コピー</translation>
+</phrase>
+
+<phrase>
+<original>cut</original>
+<translation>カット</translation>
+</phrase>
+
+<phrase>
+<original>Make current layer transforms (size, angle, and shear) permanent.  This action is never required, but if viewport rendering is sluggish, it may improve performance.</original>
+<translation>現在のレイヤーの変形 (サイズ、角度、シアー) を永続化します。  このアクションは決して必要ではありませんが、ビューポートのレンダリングが遅い場合、パフォーマンスが向上する可能性があります。</translation>
+</phrase>
+
+<!-- Toolpanel_MoveSize.frm contains 28 phrases. 10 were duplicates of existing phrases, so only 18 new phrases were written to file. -->
+
+<!-- Toolpanel_Paintbrush.frm contains 9 phrases.  All were duplicates of existing phrases, so no new phrases were written to file. -->
+
+<!-- Toolpanel_Pencil.frm contains 5 phrases.  All were duplicates of existing phrases, so no new phrases were written to file. -->
+
+<phrase>
+<original>animate</original>
+<translation>境界を強調</translation>
+</phrase>
+
+<phrase>
+<original>(no additional options)</original>
+<translation>(追加のオプションなし)</translation>
+</phrase>
+
+<phrase>
+<original>fill interior</original>
+<translation>選択範囲内を強調</translation>
+</phrase>
+
+<phrase>
+<original>fill exterior</original>
+<translation>選択範囲外を強調</translation>
+</phrase>
+
+<phrase>
+<original>open panel automatically</original>
+<translation>パネルを自動的に開く</translation>
+</phrase>
+
+<phrase>
+<original>area</original>
+<translation>エリア</translation>
+</phrase>
+
+<phrase>
+<original>round corners</original>
+<translation>角の丸み</translation>
+</phrase>
+
+<phrase>
+<original>stroke smoothing</original>
+<translation>ストロークのスムージング</translation>
+</phrase>
+
+<phrase>
+<original>combine</original>
+<translation>結合</translation>
+</phrase>
+
+<phrase>
+<original>New selection</original>
+<translation>新規選択</translation>
+</phrase>
+
+<phrase>
+<original>Add to selection</original>
+<translation>選択範囲に追加</translation>
+</phrase>
+
+<phrase>
+<original>Subtract from selection</original>
+<translation>選択範囲から削除</translation>
+</phrase>
+
+<phrase>
+<original>Intersect with selection</original>
+<translation>選択範囲と交差</translation>
+</phrase>
+
+<phrase>
+<original>always</original>
+<translation>常に</translation>
+</phrase>
+
+<phrase>
+<original>when combining</original>
+<translation>結合で選択中のとき</translation>
+</phrase>
+
+<phrase>
+<original>never</original>
+<translation>なし</translation>
+</phrase>
+
+<phrase>
+<original>feathered</original>
+<translation>ぼかし</translation>
+</phrase>
+
+<phrase>
+<original>interior</original>
+<translation>内部</translation>
+</phrase>
+
+<phrase>
+<original>exterior</original>
+<translation>外部</translation>
+</phrase>
+
+<phrase>
+<original>border</original>
+<translation>境界</translation>
+</phrase>
+
+<phrase>
+<original>Lock this value.  (Only one value can be locked at a time.  If you lock a new value, previously locked values will unlock.)</original>
+<translation>この値をロックします。  (一度にロックできる値は1つだけです。  新しい値をロックすると、以前にロックされた値はロック解除されます)</translation>
+</phrase>
+
+<phrase>
+<original>This option controls how smoothly selection edges blend with their surroundings.</original>
+<translation>このオプションは、選択範囲のエッジが周囲とどの程度滑らかになじむかを制御します。</translation>
+</phrase>
+
+<phrase>
+<original>Selections normally select the area inside their boundaries, but you can modify this behavior here.  (For advanced selection area adjustments, use the Select menu.)</original>
+<translation>選択範囲は通常、その境界の内側の領域を選択しますが、ここでこの動作を変更できます。  (高度な選択範囲の調整には、選択メニューを使います)</translation>
+</phrase>
+
+<phrase>
+<original>This option adjusts the width of the selection border.</original>
+<translation>このオプションは、選択範囲の境界線の幅を調節します。</translation>
+</phrase>
+
+<phrase>
+<original>This feathering slider allows for immediate feathering adjustments.  For performance reasons, it is limited to small radii.  For larger feathering radii, use the Select -> Feathering menu.</original>
+<translation>このぼかしスライダーは、ぼかしを即座に調整できます。  パフォーマンス上の理由から、小さな半径に制限されています。  ぼかしの半径を大きくするには、[選択] -> [ぼかし] メニューを使用します。</translation>
+</phrase>
+
+<phrase>
+<original>This option adjusts the roundness of a rectangular selection's corners.</original>
+<translation>このオプションは、長方形の選択範囲の角の丸みを調整します。</translation>
+</phrase>
+
+<phrase>
+<original>This panel can automatically open when you edit or create a selection.  On smaller screens, this may not be helpful if obscures too much of the canvas, so you can disable this behavior here.</original>
+<translation>このパネルは、選択範囲を編集または作成するときに自動的に開くことができます。  小さい画面では、キャンバスが見えにくくなって役に立たないかもしれないので、ここでこの動作を無効にできます。</translation>
+</phrase>
+
+<phrase>
+<original>This option adjusts the curvature, if any, of a polygon selection's sides.</original>
+<translation>このオプションは、多角形の選択範囲の辺の曲率を調整します。</translation>
+</phrase>
+
+<phrase>
+<original>This option increases the smoothness of a hand-drawn lasso selection.</original>
+<translation>このオプションは、手描きの投げ縄の選択範囲の滑らかさを増します。</translation>
+</phrase>
+
+<phrase>
+<original>Tolerance controls how similar a pixel must be to the target color before it is added to a magic wand selection.</original>
+<translation>トレランスは、ピクセルをマジック ワンドの選択範囲に加える前に、そのピクセルが対象の色にどれだけ似ているかをコントロールします。</translation>
+</phrase>
+
+<phrase>
+<original>The magic wand tool can operate on the entire image, or just the active layer.</original>
+<translation>マジック ワンドツールは、画像全体、またはアクティブ レイヤーだけを操作できます。</translation>
+</phrase>
+
+<phrase>
+<original>Normally, the magic wand will spread out from the target pixel, adding neighboring pixels to the selection as it goes.  Alternatively, you can have it search the entire image, without regards for continuity.</original>
+<translation>通常、マジック ワンドは対象のピクセルから広がっていき、隣接するピクセルを選択範囲に追加していきます。  あるいは、連続性を無視して画像全体を検索させることもできます。</translation>
+</phrase>
+
+<phrase>
+<original>This option controls which criteria the magic wand uses to compare pixels to the target color.</original>
+<translation>このオプションは、マジック ワンドがピクセルを対象の色と比較する際に使用する基準をコントロールします。</translation>
+</phrase>
+
+<!-- Toolpanel_Selections.frm contains 75 phrases. 42 were duplicates of existing phrases, so only 33 new phrases were written to file. -->
+
+<phrase>
+<original>click to edit text</original>
+<translation>クリックしてテキストを編集</translation>
+</phrase>
+
+<phrase>
+<original>edit text</original>
+<translation>テキストを編集</translation>
+</phrase>
+
+<phrase>
+<original>always open this panel for new text layers</original>
+<translation>新しいテキスト レイヤーのために常にこのパネルを開く</translation>
+</phrase>
+
+<phrase>
+<original>font</original>
+<translation>フォント</translation>
+</phrase>
+
+<phrase>
+<original>antialiasing</original>
+<translation>アンチエイリアス</translation>
+</phrase>
+
+<phrase>
+<original>alignment</original>
+<translation>揃え</translation>
+</phrase>
+
+<phrase>
+<original>normal</original>
+<translation>標準</translation>
+</phrase>
+
+<phrase>
+<original>crisp</original>
+<translation>くっきり</translation>
+</phrase>
+
+<phrase>
+<original>This is an advanced text layer.  To edit it with the basic text tool, you must first convert it to a basic text layer.</original>
+<translation>これは高度テキスト レイヤーです。  基本テキスト ツールで編集するには、まず基本テキスト レイヤーに変換する必要があります。</translation>
+</phrase>
+
+<phrase>
+<original>(This action is non-destructive.)</original>
+<translation>(このアクションは非破壊的です)</translation>
+</phrase>
+
+<phrase>
+<original>Click here to convert this layer to basic text.</original>
+<translation>このレイヤーを基本テキスト レイヤーに変換するにはここをクリックしてください。</translation>
+</phrase>
+
+<!-- Toolpanel_TextBasic.frm contains 23 phrases. 12 were duplicates of existing phrases, so only 11 new phrases were written to file. -->
+
+<phrase>
+<original>remap</original>
+<translation>リマップ</translation>
+</phrase>
+
+<phrase>
+<original>mirror</original>
+<translation>反転</translation>
+</phrase>
+
+<phrase>
+<original>jitter (x, y)</original>
+<translation>ゆらぎ (x, y)</translation>
+</phrase>
+
+<phrase>
+<original>inflate</original>
+<translation>膨らみ</translation>
+</phrase>
+
+<phrase>
+<original>line wrap</original>
+<translation>行の折り返し</translation>
+</phrase>
+
+<phrase>
+<original>horizontal padding</original>
+<translation>水平パディング</translation>
+</phrase>
+
+<phrase>
+<original>vertical padding</original>
+<translation>垂直パディング</translation>
+</phrase>
+
+<phrase>
+<original>outline text</original>
+<translation>テキストの輪郭</translation>
+</phrase>
+
+<phrase>
+<original>fill background</original>
+<translation>背景の塗りつぶし</translation>
+</phrase>
+
+<phrase>
+<original>outline background</original>
+<translation>背景の輪郭</translation>
+</phrase>
+
+<phrase>
+<original>fill text</original>
+<translation>テキストの塗り</translation>
+</phrase>
+
+<phrase>
+<original>fill and outline</original>
+<translation>塗りつぶしと輪郭</translation>
+</phrase>
+
+<phrase>
+<original>click to edit</original>
+<translation>クリックで編集</translation>
+</phrase>
+
+<phrase>
+<original>box</original>
+<translation>ボックス</translation>
+</phrase>
+
+<phrase>
+<original>both</original>
+<translation>両方</translation>
+</phrase>
+
+<phrase>
+<original>hiragana</original>
+<translation>ひらがな</translation>
+</phrase>
+
+<phrase>
+<original>katakana</original>
+<translation>カタカナ</translation>
+</phrase>
+
+<phrase>
+<original>simplified Chinese</original>
+<translation>簡体字中国語</translation>
+</phrase>
+
+<phrase>
+<original>traditional Chinese</original>
+<translation>繁体字</translation>
+</phrase>
+
+<phrase>
+<original>Titlecase</original>
+<translation>タイトルケース</translation>
+</phrase>
+
+<phrase>
+<original>manual only</original>
+<translation>マニュアルのみ</translation>
+</phrase>
+
+<phrase>
+<original>characters</original>
+<translation>文字</translation>
+</phrase>
+
+<phrase>
+<original>words</original>
+<translation>単語</translation>
+</phrase>
+
+<phrase>
+<original>This is a basic text layer.  To edit it with the advanced text tool, you must first convert it to an advanced text layer.</original>
+<translation>これは基本テキスト レイヤーです。  高度なテキストツールで編集するには、まず高度なテキスト レイヤーに変換する必要があります。</translation>
+</phrase>
+
+<phrase>
+<original>Click here to convert this layer to advanced text.</original>
+<translation>このレイヤーを高度テキスト レイヤーに変換するには、ここをクリックしてください。</translation>
+</phrase>
+
+<!-- Toolpanel_Typography.frm contains 60 phrases. 35 were duplicates of existing phrases, so only 25 new phrases were written to file. -->
+
+<phrase>
+<original>click here for detailed instructions (in English)</original>
+<translation>詳細な説明はここをクリック (英語)</translation>
+</phrase>
+
+<phrase>
+<original>UI elements</original>
+<translation>UI の要素</translation>
+</phrase>
+
+<phrase>
+<original>replace translation with reference text (Ctrl+U)</original>
+<translation>参照テキストで翻訳を置き換え (Ctrl+U)</translation>
+</phrase>
+
+<phrase>
+<original>list of phrases (%1 items)</original>
+<translation>フレーズのリスト (%1 個)</translation>
+</phrase>
+
+<phrase>
+<original>phrase groups</original>
+<translation>フレーズのグループ</translation>
+</phrase>
+
+<phrase>
+<original>Save this translation and proceed to the next phrase</original>
+<translation>この翻訳を保存して次のフレーズへ</translation>
+</phrase>
+
+<phrase>
+<original>translated phrase</original>
+<translation>翻訳されたフレーズ</translation>
+</phrase>
+
+<phrase>
+<original>original phrase</original>
+<translation>元のフレーズ</translation>
+</phrase>
+
+<phrase>
+<original>Auto-translate all missing phrases</original>
+<translation>すべての未翻訳フレーズを自動翻訳</translation>
+</phrase>
+
+<phrase>
+<original>reference translation from .po file</original>
+<translation>.po ファイルから翻訳を参照</translation>
+</phrase>
+
+<phrase>
+<original>(NOTE: CTRL+ENTER automatically saves and proceeds to next phrase.)</original>
+<translation>(注意: CTRL+ENTER で自動的に保存され、次のフレーズに進みます)</translation>
+</phrase>
+
+<phrase>
+<original>phrase types</original>
+<translation>フレーズのタイプ</translation>
+</phrase>
+
+<phrase>
+<original>action names</original>
+<translation>アクションの名前</translation>
+</phrase>
+
+<phrase>
+<original>message boxes</original>
+<translation>メッセージ ボックス</translation>
+</phrase>
+
+<phrase>
+<original>status bar messages</original>
+<translation>ステータス バー</translation>
+</phrase>
+
+<phrase>
+<original>tooltips</original>
+<translation>ツールチップ</translation>
+</phrase>
+
+<phrase>
+<original>files where this phrase occurs</original>
+<translation>このフレーズが用いられているファイル</translation>
+</phrase>
+
+<phrase>
+<original>miscellaneous</original>
+<translation>その他</translation>
+</phrase>
+
+<phrase>
+<original>copy system locale</original>
+<translation>システム ロケールをコピー</translation>
+</phrase>
+
+<phrase>
+<original>official ISO language codes at Wikipedia</original>
+<translation>ISO 公式の言語コードを Wikipedia で開く</translation>
+</phrase>
+
+<phrase>
+<original>author name(s)</original>
+<translation>作者名</translation>
+</phrase>
+
+<phrase>
+<original>language status</original>
+<translation>言語のステータス</translation>
+</phrase>
+
+<phrase>
+<original>language version</original>
+<translation>言語のバージョン</translation>
+</phrase>
+
+<phrase>
+<original>language name</original>
+<translation>言語名</translation>
+</phrase>
+
+<phrase>
+<original>language and country ID</original>
+<translation>言語と国のID</translation>
+</phrase>
+
+<phrase>
+<original>optional translation aids</original>
+<translation>オプションの翻訳補助ツール</translation>
+</phrase>
+
+<phrase>
+<original>free DeepL.com API key for automatic translation suggestions</original>
+<translation>自動翻訳の提案用の無料 DeepL.com API キー</translation>
+</phrase>
+
+<phrase>
+<original>language file (.po) from any other software, as a reference</original>
+<translation>言語ファイル (.po) を他のソフトウェアから参照</translation>
+</phrase>
+
+<phrase>
+<original>official ISO country codes at Wikipedia</original>
+<translation>ISO 公式の国コードを Wikipedia で開く</translation>
+</phrase>
+
+<phrase>
+<original>These optional settings can accelerate the translation process.  They are not saved to the language file.</original>
+<translation>これらのオプション設定は、翻訳の作業を加速できます。 言語ファイルには保存されません。</translation>
+</phrase>
+
+<phrase>
+<original>delete selected language file</original>
+<translation>選択された言語を削除</translation>
+</phrase>
+
+<phrase>
+<original>start new language</original>
+<translation>新規の言語で開始</translation>
+</phrase>
+
+<phrase>
+<original>edit existing language</original>
+<translation>既存の言語を編集</translation>
+</phrase>
+
+<phrase>
+<original>Automatic translations</original>
+<translation>自動翻訳</translation>
+</phrase>
+
+<phrase>
+<original>Processing phrase %1 of %2</original>
+<translation>%2 個中 %1 個目のフレーズを処理中</translation>
+</phrase>
+
+<phrase>
+<original>Automatic translation complete!</original>
+<translation>自動翻訳が完了しました!</translation>
+</phrase>
+
+<phrase>
+<original>Are you sure you want to delete %1?  (This action cannot be undone.)</original>
+<translation>本当に %1 を削除しますか? (この操作は取り消せません)</translation>
+</phrase>
+
+<phrase>
+<original>Delete language file</original>
+<translation>言語ファイルを削除</translation>
+</phrase>
+
+<phrase>
+<original>You do not have access to this folder.  Please log in as an administrator and try again.</original>
+<translation>このフォルダにアクセスできません。 管理者としてログインし、再度お試しください。</translation>
+</phrase>
+
+<phrase>
+<original>New Language</original>
+<translation>新しい言語</translation>
+</phrase>
+
+<phrase>
+<original>incomplete</original>
+<translation>未完成</translation>
+</phrase>
+
+<phrase>
+<original>enter your name here</original>
+<translation>ここに名前を入力</translation>
+</phrase>
+
+<phrase>
+<original>Unfortunately, PhotoDemon's en-US language file could not be located on this PC.  This file is included with the official release of PhotoDemon, but it may not be included with development or beta builds.
+
+To start a new translation, please download a fresh copy of PhotoDemon from PhotoDemon.org.</original>
+<translation>残念ながら、PhotoDemon の en-Us 言語ファイルは、このpc上で見つけることができませんでした。  このファイルは、PhotoDemon の公式リリースに含まれていますが、開発またはベータビルドには含まれていない可能性があります。
+
+新しい翻訳を開始するには、PhotoDemon.org から PhotoDemon の新しいコピーをダウンロードしてください。</translation>
+</phrase>
+
+<phrase>
+<original>Unfortunately, this language file could not be loaded.  It's possible the copy on this PC is out-of-date.
+
+To continue, please download a fresh copy of PhotoDemon from PhotoDemon.org.</original>
+<translation>残念ながら、この言語ファイルは読み込めませんでした。  この PC のコピーが古い可能性があります。
+
+続行するには、PhotoDemon.org から PhotoDemon の新しいコピーをダウンロードしてください。</translation>
+</phrase>
+
+<phrase>
+<original>Language file could not be loaded</original>
+<translation>言語ファイルを読み込めませんでした</translation>
+</phrase>
+
+<phrase>
+<original>phrases that don't match reference</original>
+<translation>参照と一致していないフレーズ</translation>
+</phrase>
+
+<phrase>
+<original>XML file</original>
+<translation>XML ファイル</translation>
+</phrase>
+
+<phrase>
+<original>Save current language file</original>
+<translation>現在の言語ファイルを保存</translation>
+</phrase>
+
+<phrase>
+<original>Save and exit</original>
+<translation>保存して終了</translation>
+</phrase>
+
+<phrase>
+<original>Step %1</original>
+<translation>ステップ %1</translation>
+</phrase>
+
+<phrase>
+<original>select language</original>
+<translation>言語を選択</translation>
+</phrase>
+
+<phrase>
+<original>apply language and translation settings</original>
+<translation>言語と翻訳の設定を適用</translation>
+</phrase>
+
+<phrase>
+<original>localize phrases</original>
+<translation>フレーズのローカライズ</translation>
+</phrase>
+
+<phrase>
+<original>(NOT YET SAVED)</original>
+<translation>(まだ保存されていません)</translation>
+</phrase>
+
+<phrase>
+<original>all phrases</original>
+<translation>すべてのフレーズ</translation>
+</phrase>
+
+<phrase>
+<original>translated phrases</original>
+<translation>翻訳済みのフレーズ</translation>
+</phrase>
+
+<phrase>
+<original>untranslated phrases</original>
+<translation>未翻訳のフレーズ</translation>
+</phrase>
+
+<phrase>
+<original>(saved)</original>
+<translation>(保存済み)</translation>
+</phrase>
+
+<phrase>
+<original>[translation failed]</original>
+<translation>[翻訳失敗]</translation>
+</phrase>
+
+<phrase>
+<original>[phrase not in file]</original>
+<translation>[フレーズがファイルにありません]</translation>
+</phrase>
+
+<phrase>
+<original>unknown author</original>
+<translation>作者不詳</translation>
+</phrase>
+
+<phrase>
+<original>(official translation by %1)</original>
+<translation>(公式翻訳: %1)</translation>
+</phrase>
+
+<phrase>
+<original>by %1</original>
+<translation>by %1</translation>
+</phrase>
+
+<phrase>
+<original>(autosaved on %1)</original>
+<translation>(%1 で自動保存)</translation>
+</phrase>
+
+<!-- Tools_LanguageEditor.frm contains 108 phrases. 44 were duplicates of existing phrases, so only 64 new phrases were written to file. -->
+
+<phrase>
+<original>Create macro from session history</original>
+<translation>セッション履歴からマクロを作成</translation>
+</phrase>
+
+<phrase>
+<original>first action</original>
+<translation>最初のアクション</translation>
+</phrase>
+
+<phrase>
+<original>last action</original>
+<translation>最後のアクション</translation>
+</phrase>
+
+<phrase>
+<original>WARNING: this is not a valid macro.  You must include at least one action that modifies the image.</original>
+<translation>警告: これは有効なマクロではありません。  画像を変更するアクションを少なくとも 1 つ含める必要があります。</translation>
+</phrase>
+
+<phrase>
+<original>Invalid macro</original>
+<translation>無効なマクロ</translation>
+</phrase>
+
+<phrase>
+<original>WARNING: this is not a valid macro.  The last action cannot occur after the first action.</original>
+<translation>警告: これは有効なマクロではありません。  最後のアクションは、最初のアクションの後に発生することはできません。</translation>
+</phrase>
+
+<phrase>
+<original>Your final macro will contain %1 action(s).</original>
+<translation>最終的にマクロには %1 個のアクションが含まれます。</translation>
+</phrase>
+
+<!-- Tools_MacroSession.frm contains 19 phrases. 12 were duplicates of existing phrases, so only 7 new phrases were written to file. -->
+
+<phrase>
+<original>PhotoDemon Options</original>
+<translation>PhotoDemon オプション</translation>
+</phrase>
+
+<phrase>
+<original>title bar text</original>
+<translation>タイトル バー テキスト</translation>
+</phrase>
+
+<phrase>
+<original>maximum number of recent files to remember</original>
+<translation>最近使ったファイルの項目最大数</translation>
+</phrase>
+
+<phrase>
+<original>recent files</original>
+<translation>最近使ったファイル</translation>
+</phrase>
+
+<phrase>
+<original>main window</original>
+<translation>メイン ウィンドウ</translation>
+</phrase>
+
+<phrase>
+<original>grid size</original>
+<translation>グリッド サイズ</translation>
+</phrase>
+
+<phrase>
+<original>grid colors</original>
+<translation>グリッド カラー</translation>
+</phrase>
+
+<phrase>
+<original>recent file menu text</original>
+<translation>最近使ったファイル メニューのテキスト</translation>
+</phrase>
+
+<phrase>
+<original>canvas background color</original>
+<translation>キャンバスの背景色</translation>
+</phrase>
+
+<phrase>
+<original>when images arrive from an external source (like Windows Explorer)</original>
+<translation>画像を外部ソース (Windows エクスプローラなど) から届いた場合</translation>
+</phrase>
+
+<phrase>
+<original>display tone mapping options when importing HDR and RAW images</original>
+<translation>HDR および RAW 画像の読み込み時にトーン マッピングのオプションを表示する</translation>
+</phrase>
+
+<phrase>
+<original>obey auto-rotate instructions inside image files</original>
+<translation>画像ファイルに含まれる回転の情報に従う</translation>
+</phrase>
+
+<phrase>
+<original>high-dynamic range (HDR) images</original>
+<translation>ハイダイナミック レンジ (HDR)画像</translation>
+</phrase>
+
+<phrase>
+<original>forcibly extract binary-type tags as Base64 (slow)</original>
+<translation>バイナリ型タグを強制的に Base64 として抽出 (遅い)</translation>
+</phrase>
+
+<phrase>
+<original>estimate original JPEG quality settings</original>
+<translation>元の JPEG 画質設定を推定</translation>
+</phrase>
+
+<phrase>
+<original>extract unknown tags</original>
+<translation>未知のタグを抽出</translation>
+</phrase>
+
+<phrase>
+<original>automatically hide duplicate tags</original>
+<translation>重複タグを自動的に隠す</translation>
+</phrase>
+
+<phrase>
+<original>app instances</original>
+<translation>アプリのインスタンス</translation>
+</phrase>
+
+<phrase>
+<original>session restore</original>
+<translation>セッションの復元</translation>
+</phrase>
+
+<phrase>
+<original>automatically restore sessions interrupted by system updates or reboots</original>
+<translation>システムの更新や再起動によって中断されたセッションを自動的に復元</translation>
+</phrase>
+
+<phrase>
+<original>when closing images, warn about unsaved changes</original>
+<translation>画像を閉じるとき、未保存の変更を警告</translation>
+</phrase>
+
+<phrase>
+<original>when using "Save As", set the default file format to</original>
+<translation>「名前を付けて保存」のときの既定のファイル フォーマット</translation>
+</phrase>
+
+<phrase>
+<original>when "Save" is used</original>
+<translation>「保存」するとき</translation>
+</phrase>
+
+<phrase>
+<original>safe saving</original>
+<translation>安全な保存</translation>
+</phrase>
+
+<phrase>
+<original>unsaved changes</original>
+<translation>未保存の変更</translation>
+</phrase>
+
+<phrase>
+<original>default format</original>
+<translation>既定のフォーマット</translation>
+</phrase>
+
+<phrase>
+<original>list PhotoDemon as the last-used editing software</original>
+<translation>最後に使った編集ソフトとして PhotoDemon を挙げる</translation>
+</phrase>
+
+<phrase>
+<original>default folder</original>
+<translation>既定のフォルダ</translation>
+</phrase>
+
+<phrase>
+<original>when using "Save As", set the initial folder to</original>
+<translation>「名前を付けて保存」での初期フォルダ</translation>
+</phrase>
+
+<phrase>
+<original>compress undo/redo data at the following level</original>
+<translation>「元に戻す」と「やり直し」のデータを以下のレベルで圧縮</translation>
+</phrase>
+
+<phrase>
+<original>when decorating interface elements</original>
+<translation>インターフェース要素を装飾するとき</translation>
+</phrase>
+
+<phrase>
+<original>when generating image and layer thumbnail images</original>
+<translation>画像とレイヤーのサムネイル画像を生成するとき</translation>
+</phrase>
+
+<phrase>
+<original>when rendering the image canvas</original>
+<translation>画像キャンバスをレンダリングするとき</translation>
+</phrase>
+
+<phrase>
+<original>interface</original>
+<translation>インターフェース</translation>
+</phrase>
+
+<phrase>
+<original>no compression (fastest)</original>
+<translation>圧縮なし (最速)</translation>
+</phrase>
+
+<phrase>
+<original>maximum compression (slowest)</original>
+<translation>最大圧縮 (最も遅い)</translation>
+</phrase>
+
+<phrase>
+<original>undo/redo</original>
+<translation>「元に戻す」と「やり直し」</translation>
+</phrase>
+
+<phrase>
+<original>thumbnails</original>
+<translation>サムネイル</translation>
+</phrase>
+
+<phrase>
+<original>viewport</original>
+<translation>ビューポート</translation>
+</phrase>
+
+<phrase>
+<original>use black point compensation</original>
+<translation>ブラック ポイント補正を使う</translation>
+</phrase>
+
+<phrase>
+<original>display rendering intent</original>
+<translation>ディスプレイのレンダリング インテント</translation>
+</phrase>
+
+<phrase>
+<original>available displays</original>
+<translation>利用可能なディスプレイ</translation>
+</phrase>
+
+<phrase>
+<original>turn off display color management</original>
+<translation>ディスプレイのカラー マネージメントをオフにする</translation>
+</phrase>
+
+<phrase>
+<original>use the current system profiles for each display</original>
+<translation>各ディスプレイで現在のシステム プロファイルを使用</translation>
+</phrase>
+
+<phrase>
+<original>color profile for this display</original>
+<translation>このディスプレイのカラー プロファイル</translation>
+</phrase>
+
+<phrase>
+<original>display policies</original>
+<translation>ディスプレイのポリシー</translation>
+</phrase>
+
+<phrase>
+<original>use custom profiles for each display</original>
+<translation>各ディスプレイにカスタム プロファイルを使用</translation>
+</phrase>
+
+<phrase>
+<original>high-resolution mouse input</original>
+<translation>高解像度マウス入力</translation>
+</phrase>
+
+<phrase>
+<original>reset all program settings</original>
+<translation>すべてのプログラム設定をリセット</translation>
+</phrase>
+
+<phrase>
+<original>memory usage will be displayed here</original>
+<translation>メモリ使用量はここに表示されます</translation>
+</phrase>
+
+<phrase>
+<original>memory diagnostics</original>
+<translation>メモリー診断</translation>
+</phrase>
+
+<phrase>
+<original>temporary file location</original>
+<translation>一時ファイルの場所</translation>
+</phrase>
+
+<phrase>
+<original>start over</original>
+<translation>やり直す</translation>
+</phrase>
+
+<phrase>
+<original>application settings folder</original>
+<translation>アプリケーション設定フォルダ</translation>
+</phrase>
+
+<phrase>
+<original>generate debug logs</original>
+<translation>デバッグ ログを生成</translation>
+</phrase>
+
+<phrase>
+<original>(disclaimer populated at run-time)</original>
+<translation>(免責事項は実行時に入力されます)</translation>
+</phrase>
+
+<phrase>
+<original>automatically check for updates</original>
+<translation>アップデートを自動的にチェック</translation>
+</phrase>
+
+<phrase>
+<original>allow updates from these tracks</original>
+<translation>これらのトラックからのアップデートを許可</translation>
+</phrase>
+
+<phrase>
+<original>update options</original>
+<translation>更新オプション</translation>
+</phrase>
+
+<phrase>
+<original>notify when an update is ready</original>
+<translation>アップデートの準備ができたら通知</translation>
+</phrase>
+
+<phrase>
+<original>Saving preferences</original>
+<translation>環境設定の保存</translation>
+</phrase>
+
+<phrase>
+<original>Preferences updated.</original>
+<translation>環境設定が更新されました。</translation>
+</phrase>
+
+<phrase>
+<original>Please select a color profile</original>
+<translation>カラー プロファイルを選択してください</translation>
+</phrase>
+
+<phrase>
+<original>All settings will be restored to their default values.  This action cannot be undone.
+
+Are you sure you want to continue?</original>
+<translation>すべての設定が既定値に戻されます。  この操作は元に戻せません。
+
+本当に続けますか?</translation>
+</phrase>
+
+<phrase>
+<original>Reset PhotoDemon</original>
+<translation>PhotoDemon をリセット</translation>
+</phrase>
+
+<phrase>
+<original>Interface</original>
+<translation>インターフェース</translation>
+</phrase>
+
+<phrase>
+<original>Loading</original>
+<translation>読み込み</translation>
+</phrase>
+
+<phrase>
+<original>Performance</original>
+<translation>パフォーマンス</translation>
+</phrase>
+
+<phrase>
+<original>Color management</original>
+<translation>カラー マネジメント</translation>
+</phrase>
+
+<phrase>
+<original>Updates</original>
+<translation>更新</translation>
+</phrase>
+
+<phrase>
+<original>Advanced</original>
+<translation>高度</translation>
+</phrase>
+
+<phrase>
+<original>compact (filename only)</original>
+<translation>コンパクト (ファイル名のみ)</translation>
+</phrase>
+
+<phrase>
+<original>verbose (filename and path)</original>
+<translation>詳細 (ファイル名とパス)</translation>
+</phrase>
+
+<phrase>
+<original>The title bar of the main PhotoDemon window displays information about the currently loaded image.  Use this preference to control how much information is displayed.</original>
+<translation>PhotoDemon メイン ウィンドウのタイトル バーには、現在ロードされている画像に関する情報が表示されます。  この環境設定を使用して、表示される情報量を制御します。</translation>
+</phrase>
+
+<phrase>
+<original>The "Recent Files" menu width is limited by Windows.  To prevent this menu from overflowing, PhotoDemon can display image names only instead of full image locations.</original>
+<translation>"最近使ったファイル" メニューの幅は、Windowsによって制限されています。  このメニューが溢れるのを防ぐために、PhotoDemon は、完全な画像位置の代わりに画像名のみを表示できます。</translation>
+</phrase>
+
+<phrase>
+<original>midtones</original>
+<translation>中間調</translation>
+</phrase>
+
+<phrase>
+<original>To help identify transparent pixels, a special grid appears "behind" them.  This setting modifies the grid's appearance.</original>
+<translation>透明ピクセルを識別しやすくするために、特別なグリッドがピクセルの「後ろ」に表示されます。  この設定は、グリッドの外観を変更します。</translation>
+</phrase>
+
+<phrase>
+<original>small</original>
+<translation>小さい</translation>
+</phrase>
+
+<phrase>
+<original>large</original>
+<translation>大きい</translation>
+</phrase>
+
+<phrase>
+<original>HDR and RAW images contain more colors than PC screens can physically display.  Before displaying such images, a tone mapping operation must be applied to the original image data.</original>
+<translation>HDR 画像や RAW 画像には、PC の画面では物理的に表示できないほど多くの色が含まれています。  このような画像を表示する前に、元の画像データにトーン マッピング処理を施す必要があります。</translation>
+</phrase>
+
+<phrase>
+<original>load into this instance</original>
+<translation>このインスタンスにロード</translation>
+</phrase>
+
+<phrase>
+<original>load into a new PhotoDemon instance</original>
+<translation>新しい PhotoDemon インスタンスにロード</translation>
+</phrase>
+
+<phrase>
+<original>Older cameras and photo-editing software may not embed metadata correctly, leading to multiple metadata copies within a single file.  PhotoDemon can automatically resolve duplicate entries for you.</original>
+<translation>古いカメラおよび写真編集ソフトウェアは、メタデータを正しく埋め込むことができず、1つのファイル内に複数のメタデータをコピーしてしまうことがあります。  PhotoDemon は、自動的に重複エントリを解決します。</translation>
+</phrase>
+
+<phrase>
+<original>The JPEG format does not provide a way to store JPEG quality settings inside image files.  PhotoDemon can work around this by inferring quality settings from other metadata (like quantization tables).</original>
+<translation>JPEG フォーマットは、画像ファイル内に JPEG 品質設定を保存する方法を提供しません。  PhotoDemon は、他のメタデータ (量子化テーブルのような) から品質設定を推測することにより、これを回避できます。</translation>
+</phrase>
+
+<phrase>
+<original>Some camera manufacturers store proprietary metadata tags inside image files.  These tags are not generally useful to humans, but PhotoDemon can attempt to extract them anyway.</original>
+<translation>一部のカメラメーカーは、画像ファイル内に独自のメタデータタグを保存します。  これらのタグは、一般的に人間にとって有用ではありませんが、PhotoDemon はいずれにせよ抽出を試みることができます。</translation>
+</phrase>
+
+<phrase>
+<original>By default, large binary tags (like image thumbnails) are not processed.  Instead, PhotoDemon simply reports the size of the embedded data.  If you require this data, PhotoDemon can manually convert it to Base64 for further analysis.</original>
+<translation>既定では、大きなバイナリ タグ (画像のサムネイルのような) は処理されません。  代わりに、PhotoDemon は単に埋め込まれたデータのサイズを報告します。  このデータが必要な場合、PhotoDemon はさらなる分析のために手動で Base64 に変換できます。</translation>
+</phrase>
+
+<phrase>
+<original>Most digital photos include rotation instructions (EXIF orientation metadata), which PhotoDemon will use to automatically rotate photos.  Some older smartphones and cameras may not write these instructions correctly, so if your photos are being imported sideways or upside-down, you can try disabling the auto-rotate feature.</original>
+<translation>ほとんどのデジタル写真には回転指示 (Exif 方向メタデータ) が含まれており、PhotoDemon はこれを使用して写真を自動的に回転させます。  古いスマートフォンやカメラの中には、これらの指示を正しく書き込まないものもありますので、写真が横向きや上下逆さまにインポートされる場合は、自動回転機能を無効にしてみてください。</translation>
+</phrase>
+
+<phrase>
+<original>If your PC reboots while PhotoDemon is running, PhotoDemon can automatically restore your previous session.</original>
+<translation>PhotoDemon の実行中に PC が再起動した場合、PhotoDemon は自動的に以前のセッションを復元できます。</translation>
+</phrase>
+
+<phrase>
+<original>By default, PhotoDemon will warn you when you attempt to close an image with unsaved changes.</original>
+<translation>既定では、PhotoDemon は、未保存の変更で画像を閉じようとすると警告を表示します。</translation>
+</phrase>
+
+<phrase>
+<original>the current image's folder</original>
+<translation>現在の画像のフォルダ</translation>
+</phrase>
+
+<phrase>
+<original>the last-used folder</original>
+<translation>最後に使用されたフォルダ</translation>
+</phrase>
+
+<phrase>
+<original>Most photo editors default to the current image's folder.  For workflows that involve loading images from one folder but saving to a new folder, use the last-used folder to save time.</original>
+<translation>ほとんどのフォトエディタは、現在の画像のフォルダを既定としています。  あるフォルダから画像を読み込み、新しいフォルダに保存するようなワークフローでは、最後に使用したフォルダを使用すると時間を節約できます。</translation>
+</phrase>
+
+<phrase>
+<original>the current image's format</original>
+<translation>現在の画像のフォーマット</translation>
+</phrase>
+
+<phrase>
+<original>the last-used format</original>
+<translation>最後に使用されたフォーマット</translation>
+</phrase>
+
+<phrase>
+<original>Most photo editors default to the current image's format.  For workflows that involve loading images in one format (e.g. RAW) but saving to a new format (e.g. JPEG), use the last-used format to save time.</original>
+<translation>ほとんどのフォトエディタは、現在の画像フォーマットを既定としています。  あるフォーマット (例: RAW)で画像を読み込み、新しいフォーマット (例: JPEG)で保存するワークフローでは、時間を節約するために最後に使用したフォーマットを使用します。</translation>
+</phrase>
+
+<phrase>
+<original>overwrite the current file (standard behavior)</original>
+<translation>現在のファイルを上書き (標準的な動作)</translation>
+</phrase>
+
+<phrase>
+<original>save a new copy, e.g. "filename (2).jpg" (safe behavior)</original>
+<translation>新しいコピーを保存、たとえば "ファイル名 (2).jpg" (安全な動作)</translation>
+</phrase>
+
+<phrase>
+<original>In most photo editors, the "Save" command saves the image over its original version, erasing that copy forever.  PhotoDemon provides a "safer" option, where each save results in a new copy of the file.</original>
+<translation>ほとんどのフォトエディタでは、"保存 "コマンドは、元のバージョンの上に画像を保存し、そのコピーを永遠に消去します。  PhotoDemon は、各保存がファイルの新しいコピーになる「より安全な」オプションを提供します。</translation>
+</phrase>
+
+<phrase>
+<original>The EXIF specification asks programs to correctly identify themselves as the software of origin when exporting image files.  For increased privacy, you can suspend this behavior.</original>
+<translation>EXIF 仕様は、画像ファイルをエクスポートする際に、自分自身を元のソフトウェアとして正しく識別するようプログラムに要求します。  プライバシーを高めるために、この動作を一時停止できます。</translation>
+</phrase>
+
+<phrase>
+<original>maximize quality</original>
+<translation>最大限の品質</translation>
+</phrase>
+
+<phrase>
+<original>balance performance and quality</original>
+<translation>性能と品質のバランス</translation>
+</phrase>
+
+<phrase>
+<original>maximize performance</original>
+<translation>最大限のパフォーマンス</translation>
+</phrase>
+
+<phrase>
+<original>Some interface elements receive custom decorations (like drop shadows).  On older PCs, these decorations can be suspended for a small performance boost.</original>
+<translation>一部のインターフェイス要素には、カスタム装飾 (ドロップシャドウなど) が施されています。  古いPC では、これらの装飾を一時停止することで、パフォーマンスを少し上げることができます。</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon generates many thumbnail images, especially when images contain multiple layers.  Thumbnail quality can be lowered to improve performance.</original>
+<translation>PhotoDemon は、特に画像が複数のレイヤーを含む場合、多くのサムネイル画像を生成します。  サムネイルの品質は、パフォーマンスを向上させるために下げることができます。</translation>
+</phrase>
+
+<phrase>
+<original>Rendering the primary image canvas is a common bottleneck for PhotoDemon's performance.  The automatic setting is recommended, but for older PCs, you can manually select the Maximize Performance option to sacrifice quality for raw performance.</original>
+<translation>主画像キャンバスのレンダリングは、PhotoDemon のパフォーマンスの一般的なボトルネックです。  自動設定が推奨されますが、古いPCの場合、手動でパフォーマンスの最大化オプションを選択し、品質と引き換えにパフォーマンスを向上できます。</translation>
+</phrase>
+
+<phrase>
+<original>Low compression settings require more disk space, but undo/redo operations will be faster.  High compression settings require less disk space, but undo/redo operations will be slower.  Undo data is erased when images are closed, so this setting only affects disk space while images are actively being edited.</original>
+<translation>低圧縮設定は、より多くのディスク スペースを必要としますが、アンドゥ/リドゥ操作はより速くなります。  圧縮率を高く設定すると、必要なディスク容量は少なくなりますが、アンドゥ/リドゥの処理速度は遅くなります。  元に戻すデータは画像を閉じると消去されるため、この設定がディスク容量に影響するのは、画像がアクティブに編集されている間だけです。</translation>
+</phrase>
+
+<phrase>
+<original>Primary display</original>
+<translation>主ディスプレイ</translation>
+</phrase>
+
+<phrase>
+<original>Secondary display</original>
+<translation>副ディスプレイ</translation>
+</phrase>
+
+<phrase>
+<original>Turning off display color management can provide a small performance boost.  If your display is not currently configured for color management, use this setting.</original>
+<translation>ディスプレイのカラー マネージメントをオフにすると、パフォーマンスが少し向上します。  お使いのディスプレイが現在カラーマネージメント用に設定されていない場合は、この設定を使用してください。</translation>
+</phrase>
+
+<phrase>
+<original>This setting is the best choice for most users.  If you have no idea what color management is, use this setting.  If you have correctly configured a display profile via the Windows Control Panel, also use this setting.</original>
+<translation>この設定は、ほとんどのユーザーにとって最良の選択です。  カラー マネジメントが何なのかわからない場合は、この設定を使用してください。  Windows コントロール パネルでディスプレイ プロファイルを正しく設定した場合も、この設定を使用します。</translation>
+</phrase>
+
+<phrase>
+<original>To configure custom color profiles on a per-monitor basis, please use this setting.</original>
+<translation>モニターごとにカスタム カラー プロファイルを設定するには、この設定を使用してください。</translation>
+</phrase>
+
+<phrase>
+<original>Please specify a color profile for each monitor currently attached to the system.  Note that the text in parentheses is the display adapter driving the named monitor.</original>
+<translation>現在システムに接続されている各モニターのカラー プロファイルを指定してください。  括弧内のテキストは、指定されたモニターを駆動するディスプレイ アダプターであることに注意してください。</translation>
+</phrase>
+
+<phrase>
+<original>Click this button to bring up a "browse for color profile" dialog.</original>
+<translation>このボタンをクリックすると、「カラー プロファイルの参照」ダイアログが表示されます。</translation>
+</phrase>
+
+<phrase>
+<original>If you do not know what this setting controls, set it to "Perceptual".  Perceptual rendering intent is the best choice for most users.</original>
+<translation>この設定が何を制御するのかわからない場合は、「知覚的」に設定してください。  知覚的レンダリング インテントは、ほとんどのユーザーにとって最良の選択です。</translation>
+</phrase>
+
+<phrase>
+<original>BPC is primarily relevant in colorimetric rendering intents, where it helps preserve detail in dark (shadow) regions of images.  For most workflows, BPC should be turned ON.</original>
+<translation>BPC は主に、画像の暗い (シャドウ) 領域のディテールを保持するのに役立つ、比色レンダリングの意図に関連しています。  ほとんどのワークフローでは、BPC をオンにする必要があります。</translation>
+</phrase>
+
+<phrase>
+<original>each session</original>
+<translation>セッションごと</translation>
+</phrase>
+
+<phrase>
+<original>weekly</original>
+<translation>毎週</translation>
+</phrase>
+
+<phrase>
+<original>monthly</original>
+<translation>毎月</translation>
+</phrase>
+
+<phrase>
+<original>never (not recommended)</original>
+<translation>しない (非推奨)</translation>
+</phrase>
+
+<phrase>
+<original>Because PhotoDemon is a portable application, it can only check for updates when the program is running.  By default, PhotoDemon will check for updates whenever the program is launched, but you can reduce this frequency if desired.</original>
+<translation>PhotoDemon はポータブル アプリケーションであるため、プログラムの実行時にのみアップデートを確認できます。  既定では、PhotoDemon はプログラム起動時にアップデートをチェックしますが、必要に応じてこの頻度を減らすことができます。</translation>
+</phrase>
+
+<phrase>
+<original>stable releases</original>
+<translation>安定リリース</translation>
+</phrase>
+
+<phrase>
+<original>stable and beta releases</original>
+<translation>安定リリースとベータ リリース</translation>
+</phrase>
+
+<phrase>
+<original>stable, beta, and developer releases</original>
+<translation>安定版、ベータ版、開発者リリース</translation>
+</phrase>
+
+<phrase>
+<original>One of the best ways to support PhotoDemon is to help test new releases.  By default, PhotoDemon will suggest both stable and beta releases, but the truly adventurous can also try developer releases.  (Developer releases give you immediate access to the latest program enhancements, but you might encounter some bugs.)</original>
+<translation>PhotoDemonをサポートする最良の方法の1つは、新しいリリースのテストに協力することです。  既定では、PhotoDemon は安定リリースとベータ リリースの両方を提案しますが、本当に冒険好きな方は、開発者リリースを試すこともできます。  (開発者リリースでは、最新のプログラム拡張にすぐにアクセスできますが、バグに遭遇する可能性があります)</translation>
+</phrase>
+
+<phrase>
+<original>PhotoDemon can notify you when it's ready to apply an update.  This allows you to use the updated version immediately.</original>
+<translation>PhotoDemon は、アップデートを適用する準備ができたときに通知できます。  これにより、更新されたバージョンをすぐに使用できます。</translation>
+</phrase>
+
+<phrase>
+<original>You have placed PhotoDemon in a restricted system folder.  Security precautions prevent PhotoDemon from modifying this folder, so automatic updates are now disabled.  To restore them, you must move PhotoDemon to a non-admin folder, like Desktop, Documents, or Downloads.
+
+(If you leave PhotoDemon where it is, please don't forget to visit PhotoDemon.org from time to time to check for new versions.)</original>
+<translation>制限されたシステム フォルダに PhotoDemon を配置しました。  セキュリティ対策により、PhotoDemon はこのフォルダを変更できないため、自動アップデートは現在無効になっています。  復元するには、PhotoDemonをデスクトップ、ドキュメント、またはダウンロードのような非管理フォルダに移動する必要があります。
+
+(PhotoDemon をそのままにしておく場合、新しいバージョンをチェックするために時々 PhotoDemon.org を訪問することを忘れないでください)</translation>
+</phrase>
+
+<phrase>
+<original>The developers of PhotoDemon take privacy very seriously, so no information - statistical or otherwise - is uploaded during the update process.  Updates simply involve downloading several small XML files from PhotoDemon.org. These files contain the latest software, plugin, and language version numbers. If updated versions are found, and user preferences allow, the updated files are then downloaded and patched automatically.
+
+If you still choose to disable updates, don't forget to visit PhotoDemon.org from time to time to check for new versions.</original>
+<translation>PhotoDemon の開発者は、プライバシーを非常に重要視しているため、更新処理中に統計的またはその他の情報がアップロードされることはありません。  アップデートは、PhotoDemon.org からいくつかの小さな XML ファイルをダウンロードするだけです。これらのファイルは、最新のソフトウェア、プラグイン、および言語バージョン番号を含んでいます。更新されたバージョンが発見され、ユーザー設定が許可する場合、更新されたファイルは自動的にダウンロードされ、パッチが適用されます。
+
+アップデートを無効にする場合、時々 PhotoDemon.org を訪問し、新しいバージョンをチェックすることを忘れないでください。</translation>
+</phrase>
+
+<phrase>
+<original>In developer builds, debug data is automatically logged to the program's \Data\Debug folder.  If you encounter bugs in a stable release, please manually activate this setting.  This will help developers resolve your problem.</original>
+<translation>開発者用ビルドでは、デバッグ データは自動的にプログラムの一時フォルダに記録されます。  安定版リリースでバグに遭遇した場合は、手動でこの設定を有効にしてください。  これは、開発者があなたの問題を解決するのに役立ちます。</translation>
+</phrase>
+
+<phrase>
+<original>When using Remote Desktop or a VM (Virtual Machine), high-resolution mouse input may not work correctly.  This is a long-standing Windows bug.  In these situations, you can use this setting to restore correct mouse behavior.</original>
+<translation>リモート デスクトップまたは VM (仮想マシン) を使用している場合、高解像度のマウス入力が正しく動作しないことがあります。  これは Windows の長年のバグです。  このような状況では、この設定を使用して正しいマウス動作を復元できます。</translation>
+</phrase>
+
+<phrase>
+<original>current PhotoDemon memory usage</original>
+<translation>現在の PhotoDemon のメモリ使用量</translation>
+</phrase>
+
+<phrase>
+<original>max PhotoDemon memory usage this session</original>
+<translation>このセッションにおける PhotoDemon の最大メモリ使用量</translation>
+</phrase>
+
+<phrase>
+<original>Click to select a new temporary folder.</original>
+<translation>クリックして新しい一時フォルダを選択します。</translation>
+</phrase>
+
+<phrase>
+<original>This button resets all PhotoDemon settings.  If the program is behaving unexpectedly, this may resolve the problem.</original>
+<translation>このボタンは、全ての PhotoDemon 設定をリセットします。  プログラムが予期しない動作をしている場合、これにより問題が解決することがあります。</translation>
+</phrase>
+
+<phrase>
+<original>WARNING: this folder is invalid (access prohibited).  Please provide a valid folder.  If a new folder is not provided, PhotoDemon will use the system temp folder.</original>
+<translation>警告: このフォルダは無効です (アクセス禁止)。  有効なフォルダを指定してください。  新しいフォルダが提供されない場合、PhotoDemon はシステムの一時フォルダを使用します。</translation>
+</phrase>
+
+<phrase>
+<original>This new temporary folder location will not take effect until you restart the program.</original>
+<translation>この新しい一時フォルダの場所は、プログラムを再起動するまで有効になりません。</translation>
+</phrase>
+
+<!-- Tools_Options.frm contains 190 phrases. 55 were duplicates of existing phrases, so only 135 new phrases were written to file. -->
+
+<phrase>
+<original>Reset all library options</original>
+<translation>すべてのライブラリ オプションをリセット</translation>
+</phrase>
+
+<phrase>
+<original>library details</original>
+<translation>ライブラリの詳細</translation>
+</phrase>
+
+<phrase>
+<original>library status</original>
+<translation>ライブラリの状態</translation>
+</phrase>
+
+<phrase>
+<original>GOOD</original>
+<translation>GOOD</translation>
+</phrase>
+
+<phrase>
+<original>library folder</original>
+<translation>ライブラリのフォルダ</translation>
+</phrase>
+
+<phrase>
+<original>forcibly disable</original>
+<translation>強制的に無効にする</translation>
+</phrase>
+
+<phrase>
+<original>homepage</original>
+<translation>ホームページ</translation>
+</phrase>
+
+<phrase>
+<original>license</original>
+<translation>ライセンス</translation>
+</phrase>
+
+<phrase>
+<original>%1 summary</original>
+<translation>%1 要約</translation>
+</phrase>
+
+<phrase>
+<original>expected version</original>
+<translation>期待されるバージョン</translation>
+</phrase>
+
+<phrase>
+<original>version found</original>
+<translation>見つかったバージョン</translation>
+</phrase>
+
+<phrase>
+<original>Plugin options saved.</original>
+<translation>プラグインのオプションが保存されました。</translation>
+</phrase>
+
+<phrase>
+<original>Overview</original>
+<translation>オーバービュー</translation>
+</phrase>
+
+<phrase>
+<original>problems detected</original>
+<translation>問題を検出</translation>
+</phrase>
+
+<phrase>
+<original>installed and up to date</original>
+<translation>最新版がインストール済み</translation>
+</phrase>
+
+<phrase>
+<original>installed, but version is unexpected</original>
+<translation>インストールされているが、バージョンが予期しない</translation>
+</phrase>
+
+<phrase>
+<original>installed, but disabled by user</original>
+<translation>インストールされているが、ユーザーによって無効化されている</translation>
+</phrase>
+
+<phrase>
+<original>not installed</original>
+<translation>未インストール</translation>
+</phrase>
+
+<phrase>
+<original>not installed, but available on-demand</original>
+<translation>インストールされていないが、オンデマンドで利用可能</translation>
+</phrase>
+
+<phrase>
+<original>missing</original>
+<translation>見つからない</translation>
+</phrase>
+
+<phrase>
+<original>an AVIF image</original>
+<translation>AVIF 画像</translation>
+</phrase>
+
+<phrase>
+<original>This library does not ship with PhotoDemon.</original>
+<translation>このライブラリは PhotoDemon に同梱されません。</translation>
+</phrase>
+
+<phrase>
+<original>If you interact with %1, PhotoDemon will offer to download and configure this library for you.</original>
+<translation>%1 に影響する場合、PhotoDemon はこのライブラリのダウンロードおよび設定を提供します。</translation>
+</phrase>
+
+<!-- Tools_PluginManager.frm contains 46 phrases. 23 were duplicates of existing phrases, so only 23 new phrases were written to file. -->
+
+<phrase>
+<original>Select capture area</original>
+<translation>キャプチャ領域を選択</translation>
+</phrase>
+
+<phrase>
+<original>End recording</original>
+<translation>録画終了</translation>
+</phrase>
+
+<phrase>
+<original>Recording will start in %1</original>
+<translation>あと %1 秒で録画開始</translation>
+</phrase>
+
+<phrase>
+<original>capture</original>
+<translation>キャプチャ</translation>
+</phrase>
+
+<phrase>
+<original>Recording - %1:%2 @ %3 fps</original>
+<translation>録画中 - %1:%2 @ %3 fps</translation>
+</phrase>
+
+<!-- Tools_ScreenVideo.frm contains 37 phrases. 32 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
+
+<phrase>
+<original>open in PhotoDemon (for further editing)</original>
+<translation>PhotoDemon で開く (さらに編集するため)</translation>
+</phrase>
+
+<phrase>
+<original>recording settings</original>
+<translation>録画設定</translation>
+</phrase>
+
+<phrase>
+<original>target frame rate (fps)</original>
+<translation>目標フレームレート (fps)</translation>
+</phrase>
+
+<phrase>
+<original>repeat final animation</original>
+<translation>最後のアニメーションを繰り返す</translation>
+</phrase>
+
+<phrase>
+<original>record mouse actions</original>
+<translation>マウス操作を記録</translation>
+</phrase>
+
+<phrase>
+<original>countdown before starting (in seconds)</original>
+<translation>開始前のカウントダウン (秒)</translation>
+</phrase>
+
+<phrase>
+<original>when recording finishes</original>
+<translation>録画終了時</translation>
+</phrase>
+
+<phrase>
+<original>save directly to image file</original>
+<translation>画像ファイルに直接保存</translation>
+</phrase>
+
+<phrase>
+<original>cursor only</original>
+<translation>カーソルのみ</translation>
+</phrase>
+
+<phrase>
+<original>cursor and clicks</original>
+<translation>カーソルとクリック</translation>
+</phrase>
+
+<!-- Tools_ScreenVideoPrefs.frm contains 19 phrases. 9 were duplicates of existing phrases, so only 10 new phrases were written to file. -->
+
+<!-- Automatic text generation complete. -->
+
+<phrasecount>2640</phrasecount>
+
+<!-- As of this build, PhotoDemon contains 5515 phrases. -->
+<!-- 2875 are duplicates, so only 2640 unique phrases have been written to file. -->
+<!-- These 2640 phrases contain approximately 11421 total words. -->
+
+</pdData>

--- a/App/PhotoDemon/Languages/Japanese.xml
+++ b/App/PhotoDemon/Languages/Japanese.xml
@@ -710,7 +710,7 @@
 
 <phrase>
 <original>Vibrance</original>
-<translation>自然な彩度</translation>
+<translation>彩度</translation>
 </phrase>
 
 <phrase>
@@ -720,12 +720,12 @@
 
 <phrase>
 <original>Channel mixer</original>
-<translation>チャンネ ルミキサー</translation>
+<translation>チャンネル ミキサー</translation>
 </phrase>
 
 <phrase>
 <original>Rechannel</original>
-<translation>リチャンネル</translation>
+<translation>再チャンネル</translation>
 </phrase>
 
 <phrase>
@@ -740,12 +740,12 @@
 
 <phrase>
 <original>Shift colors (left)</original>
-<translation>シフトカラー (左)</translation>
+<translation>色をシフト (左)</translation>
 </phrase>
 
 <phrase>
 <original>Shift colors (right)</original>
-<translation>シフトカラー (右)</translation>
+<translation>色をシフト (右)</translation>
 </phrase>
 
 <phrase>
@@ -760,7 +760,7 @@
 
 <phrase>
 <original>Tint</original>
-<translation>色合い</translation>
+<translation>色調</translation>
 </phrase>
 
 <phrase>
@@ -790,7 +790,7 @@
 
 <phrase>
 <original>Split toning</original>
-<translation>トーニングを分割</translation>
+<translation>分割トーン</translation>
 </phrase>
 
 <phrase>
@@ -800,27 +800,27 @@
 
 <phrase>
 <original>Stretch histogram</original>
-<translation>ヒストグラムを伸張</translation>
+<translation>ヒストグラムを伸ばす</translation>
 </phrase>
 
 <phrase>
 <original>Film negative</original>
-<translation>フィルムネガ</translation>
+<translation>フィルム ネガ</translation>
 </phrase>
 
 <phrase>
 <original>Invert hue</original>
-<translation>色相を反転させる</translation>
+<translation>色相を反転</translation>
 </phrase>
 
 <phrase>
 <original>Invert RGB</original>
-<translation>Rgb反転</translation>
+<translation>RGB を反転</translation>
 </phrase>
 
 <phrase>
 <original>Dehaze</original>
-<translation>デヘイズ</translation>
+<translation>かすみを除去</translation>
 </phrase>
 
 <phrase>
@@ -850,12 +850,12 @@
 
 <phrase>
 <original>Color to monochrome</original>
-<translation>カラーからモノクロへ</translation>
+<translation>カラーをモノクロに</translation>
 </phrase>
 
 <phrase>
 <original>Monochrome to gray</original>
-<translation>モノクロからグレーへ</translation>
+<translation>モノクロをグレーに</translation>
 </phrase>
 
 <phrase>
@@ -870,7 +870,7 @@
 
 <phrase>
 <original>Figured glass</original>
-<translation>フィギュアドグラス</translation>
+<translation>模様入りガラス</translation>
 </phrase>
 
 <phrase>
@@ -890,7 +890,7 @@
 
 <phrase>
 <original>Modern art</original>
-<translation>モダンアート</translation>
+<translation>現代アート</translation>
 </phrase>
 
 <phrase>
@@ -900,7 +900,7 @@
 
 <phrase>
 <original>Plastic wrap</original>
-<translation>ラップ</translation>
+<translation>プラスチック ラップ</translation>
 </phrase>
 
 <phrase>
@@ -910,7 +910,7 @@
 
 <phrase>
 <original>Relief</original>
-<translation>リレーフ</translation>
+<translation>レリーフ</translation>
 </phrase>
 
 <phrase>
@@ -960,12 +960,12 @@
 
 <phrase>
 <original>Droste</original>
-<translation>ドロステ</translation>
+<translation>ドロステ効果</translation>
 </phrase>
 
 <phrase>
 <original>Apply lens distortion</original>
-<translation>レンズ ディストーションを適用</translation>
+<translation>レンズ歪みの適用</translation>
 </phrase>
 
 <phrase>
@@ -975,7 +975,7 @@
 
 <phrase>
 <original>Poke</original>
-<translation>ポーク</translation>
+<translation>突く</translation>
 </phrase>
 
 <phrase>
@@ -990,7 +990,7 @@
 
 <phrase>
 <original>Swirl</original>
-<translation>渦巻き</translation>
+<translation>うず巻き</translation>
 </phrase>
 
 <phrase>
@@ -1000,7 +1000,7 @@
 
 <phrase>
 <original>Miscellaneous distort</original>
-<translation>雑多な歪み</translation>
+<translation>その他の歪み</translation>
 </phrase>
 
 <phrase>
@@ -1030,7 +1030,7 @@
 
 <phrase>
 <original>Trace contour</original>
-<translation>輪郭検出</translation>
+<translation>輪郭を追跡</translation>
 </phrase>
 
 <phrase>
@@ -1055,17 +1055,17 @@
 
 <phrase>
 <original>Sunshine</original>
-<translation>日照</translation>
+<translation>太陽光</translation>
 </phrase>
 
 <phrase>
 <original>Dilate (maximum rank)</original>
-<translation>広げる (最高ランク)</translation>
+<translation>拡張 (最大ランク)</translation>
 </phrase>
 
 <phrase>
 <original>Erode (minimum rank)</original>
-<translation>浸食浸食 (最低ランク)</translation>
+<translation>浸食 (最小ランク)</translation>
 </phrase>
 
 <phrase>
@@ -1080,7 +1080,7 @@
 
 <phrase>
 <original>Ignite</original>
-<translation>発火</translation>
+<translation>燃焼</translation>
 </phrase>
 
 <phrase>
@@ -1090,7 +1090,7 @@
 
 <phrase>
 <original>Metal</original>
-<translation>メタル</translation>
+<translation>金属</translation>
 </phrase>
 
 <phrase>
@@ -1120,7 +1120,7 @@
 
 <phrase>
 <original>Dust and scratches</original>
-<translation>埃と傷</translation>
+<translation>ほこりと傷</translation>
 </phrase>
 
 <phrase>
@@ -1170,7 +1170,7 @@
 
 <phrase>
 <original>Pointillize</original>
-<translation>ポインティライズ</translation>
+<translation>点描化</translation>
 </phrase>
 
 <phrase>
@@ -1225,7 +1225,7 @@
 
 <phrase>
 <original>Portrait glow</original>
-<translation>肖像画の輝き</translation>
+<translation>ポートレート発光</translation>
 </phrase>
 
 <phrase>
@@ -1235,7 +1235,7 @@
 
 <phrase>
 <original>Twins</original>
-<translation>双子</translation>
+<translation>軸対称</translation>
 </phrase>
 
 <phrase>
@@ -1265,7 +1265,7 @@
 
 <phrase>
 <original>Shear</original>
-<translation>剪断変形</translation>
+<translation>シアー</translation>
 </phrase>
 
 <phrase>
@@ -1349,7 +1349,7 @@
 
 <phrase>
 <original>Autosave could not be fully reconstructed.  Partial reconstruction attempted instead.</original>
-<translation>自動セーブを完全に再構築できませんでした。  かわりに部分的な再構築が試みられました。</translation>
+<translation>自動保存を完全に再構築できませんでした。  かわりに部分的な再構築が試みられました。</translation>
 </phrase>
 
 <!-- AutosaveEngine.bas contains 2 phrases.  Both phrases were unique, so 2 new phrases were written to file. -->
@@ -1373,7 +1373,7 @@
 
 <phrase>
 <original>ICC profile</original>
-<translation>ICCプロファイル</translation>
+<translation>ICC プロファイル</translation>
 </phrase>
 
 <phrase>
@@ -1400,7 +1400,7 @@
 
 <phrase>
 <original>Add it to the current image as a new layer.</original>
-<translation>新規レイヤーとして現在の画像に追加します。</translation>
+<translation>現在の画像に新規レイヤーとして追加する。</translation>
 </phrase>
 
 <phrase>
@@ -1434,7 +1434,7 @@
 
 <phrase>
 <original>The tag database handles technical details of the 20,000+ metadata tags supported by PhotoDemon.  Creating the database takes 10 to 15 seconds, and it only needs to be created once, when the metadata editor is used for the first time.</original>
-<translation>タグ データベースは、PhotoDemon がサポートする 20,000 以上のメタデータ タグの技術的な詳細を処理します。  データベースの作成は 10 秒から 15 秒かかり、メタデータ エディタが初めて使用されるときに、一度だけ作成する必要があります。</translation>
+<translation>タグ データベースは、PhotoDemon でサポートされている 20,000 以上のメタデータ タグの技術的な詳細を処理します。  データベースの作成には 10 から 15 秒かかります。  作成する必要があるのは、メタデータ エディタを初めて使用するときに 1 回だけです。</translation>
 </phrase>
 
 <phrase>
@@ -1468,28 +1468,28 @@
 <original>Before lossless copies can be saved, you must save this image at least once.
 
 Lossless copies will be saved to the same folder as this initial image save.</original>
-<translation>ロスレス コピーを保存する前に、少なくとも一度はこの画像を保存する必要があります。
+<translation>ロスレス コピーを保存する前に、このイメージを少なくとも 1 回保存する必要があります。
 
-ロスレス コピーは、この最初の画像保存と同じフォルダに保存されます。</translation>
+ロスレス コピーは、この最初の画像保存と同じフォルダーに保存されます。</translation>
 </phrase>
 
 <phrase>
 <original>Initial save required</original>
-<translation>初期セーブが必要</translation>
+<translation>初期保存が必要です</translation>
 </phrase>
 
 <phrase>
 <original>Save canceled.</original>
-<translation>キャンセルされました。</translation>
+<translation>保存がキャンセルされました。</translation>
 </phrase>
 
 <phrase>
 <original>An unspecified error occurred when attempting to save this image.  Please try saving the image to an alternate format.
 
 If the problem persists, please report it to the PhotoDemon developers via PhotoDemon.org/contact</original>
-<translation>この画像を保存しようとすると、特定できないエラーが発生しました。  別の形式で画像を保存してみてください。
+<translation>この画像を保存しようとしたときに、原因不明のエラーが発生しました。画像を別の形式で保存してみてください。
 
-問題が解決しない場合、PhotoDemon.org/contact 経由で PhotoDemon 開発者に報告してください。</translation>
+問題が解決しない場合は、PhotoDemon.org/contact 経由で PhotoDemon 開発者に報告してください。</translation>
 </phrase>
 
 <phrase>
@@ -1526,7 +1526,7 @@ If the problem persists, please report it to the PhotoDemon developers via Photo
 
 <phrase>
 <original>Adjusting image white balance</original>
-<translation>画像のホワイトバランスを調整</translation>
+<translation>画像のホワイト バランスを調整</translation>
 </phrase>
 
 <phrase>
@@ -1546,12 +1546,12 @@ If the problem persists, please report it to the PhotoDemon developers via Photo
 
 <phrase>
 <original>Isolating maximum color channels</original>
-<translation>最大カラーチャンネルの分離</translation>
+<translation>最大のカラー チャネルの分離</translation>
 </phrase>
 
 <phrase>
 <original>Isolating minimum color channels</original>
-<translation>最小カラーチャンネルの分離</translation>
+<translation>最小のカラー チャネルの分離</translation>
 </phrase>
 
 <phrase>
@@ -1592,9 +1592,9 @@ If the problem persists, please report it to the PhotoDemon developers via Photo
 <original>This image contains %1 unique colors (RGB).
 
 This image contains %2 unique color + opacity values (RGBA).</original>
-<translation>この画像には、固有の %1 色 (RGB) が含まれています。
+<translation>この画像には %1 個の固有の色 (RGB) が含まれています。
 
-この画像には、固有の %2 色と不透明度の値 (RGBA) が含まれています。</translation>
+この画像には、%2 個の固有の色 + 不透明度値 (RGBA) が含まれています。</translation>
 </phrase>
 
 <!-- Filters_Misc.bas contains 4 phrases.  One was a duplicate of an existing phrase, so only 3 new phrases were written to file. -->
@@ -1680,7 +1680,7 @@ This image contains %2 unique color + opacity values (RGBA).</original>
 
 <phrase>
 <original>Image is all one color.  Autocrop unnecessary.</original>
-<translation>画像はすべて1色。  オート クロップは不要。</translation>
+<translation>画像は全1色です。  オートクロップは不要です。</translation>
 </phrase>
 
 <phrase>
@@ -1737,7 +1737,7 @@ This image contains %2 unique color + opacity values (RGBA).</original>
 
 <phrase>
 <original>Loading page %1 of %2</original>
-<translation>ページ %1 / %2 をロードしています</translation>
+<translation>ページ %1 / %2 を読み込んでいます</translation>
 </phrase>
 
 <phrase>
@@ -1754,7 +1754,7 @@ This image contains %2 unique color + opacity values (RGBA).</original>
 
 <phrase>
 <original>Stretching histogram</original>
-<translation>ヒストグラムを伸張</translation>
+<translation>ヒストグラムを伸ばす</translation>
 </phrase>
 
 <!-- Histograms.bas contains 2 phrases.  One was a duplicate of an existing phrase, so only 1 new phrases were written to file. -->
@@ -1831,7 +1831,7 @@ To enable support for this image format, please copy the FreeImage.dll file (dow
 
 <phrase>
 <original>An error has occurred (#%1 - %2).  PDI load abandoned.</original>
-<translation>エラーが発生しました (#%1 - %2)。  PDI ロードを中断しました。</translation>
+<translation>エラーが発生しました (#%1 - %2)。  PDI の読み込みを中断しました。</translation>
 </phrase>
 
 <!-- ImageLoader.bas contains 2 phrases.  One was a duplicate of an existing phrase, so only 1 new phrases were written to file. -->
@@ -2098,7 +2098,7 @@ To enable support for this image format, please copy the FreeImage.dll file (dow
 
 <phrase>
 <original>Are you sure you want to cancel %1?</original>
-<translation>本当に%1をキャンセルしますか?</translation>
+<translation>%1 をキャンセルしてもよろしいですか?</translation>
 </phrase>
 
 <phrase>
@@ -2108,7 +2108,7 @@ To enable support for this image format, please copy the FreeImage.dll file (dow
 
 <phrase>
 <original>preview not available</original>
-<translation>プレビュー不可</translation>
+<translation>プレビューは利用できません</translation>
 </phrase>
 
 <!-- Interface.bas contains 83 phrases. 28 were duplicates of existing phrases, so only 55 new phrases were written to file. -->
@@ -2120,7 +2120,7 @@ To enable support for this image format, please copy the FreeImage.dll file (dow
 
 <phrase>
 <original>Group start</original>
-<translation>グループスタート</translation>
+<translation>グループ開始</translation>
 </phrase>
 
 <phrase>
@@ -2165,7 +2165,7 @@ To enable support for this image format, please copy the FreeImage.dll file (dow
 
 <phrase>
 <original>Conversion complete.</original>
-<translation>コンバージョンを完了しました。</translation>
+<translation>変換を完了しました。</translation>
 </phrase>
 
 <phrase>
@@ -2175,12 +2175,12 @@ To enable support for this image format, please copy the FreeImage.dll file (dow
 
 <phrase>
 <original>Merged layers</original>
-<translation>マージされたレイヤー</translation>
+<translation>結合されたレイヤー</translation>
 </phrase>
 
 <phrase>
 <original>This action will convert text and vector layers to image (raster) layers, meaning you can no longer modify layer-specific settings like text, font, color or shape.</original>
-<translation>このアクションは、テキストとベクター レイヤーをイメージ (ラスター)レイヤーに変換します。つまり、テキスト、フォント、カラー、シェイプなどのレイヤー固有の設定を変更できなくなります。</translation>
+<translation>このアクションにより、テキスト レイヤーとベクター レイヤーが画像 (ラスター) レイヤーに変換されます。  つまり、テキスト、フォント、色、形状などのレイヤー固有の設定を変更できなくなります。</translation>
 </phrase>
 
 <phrase>
@@ -2215,7 +2215,7 @@ To enable support for this image format, please copy the FreeImage.dll file (dow
 
 <phrase>
 <original>In the future, automatically rasterize without prompting me</original>
-<translation>将来的には、プロンプトを出さずに自動的にラスタライズされます</translation>
+<translation>今後は、プロンプトを表示せずに自動的にラスタライズします</translation>
 </phrase>
 
 <phrase>
@@ -2237,7 +2237,7 @@ To enable support for this image format, please copy the FreeImage.dll file (dow
 
 <phrase>
 <original>Loading image</original>
-<translation>画像を読み込む</translation>
+<translation>画像を読み込んでいます</translation>
 </phrase>
 
 <phrase>
@@ -2251,7 +2251,7 @@ To enable support for this image format, please copy the FreeImage.dll file (dow
 If this image was originally located on removable media (DVD, USB drive, etc), please re-insert or re-attach the media and try again.</original>
 <translation>残念ながら、画像 '%1' が見つかりません。
 
-この画像が元々リムーバブル メディア (DVD、USBドライブなど)にあった場合は、メディアを再挿入または再装着して再試行してください。</translation>
+この画像が元々リムーバブル メディア (DVD、USBドライブなど) にあった場合は、メディアを再挿入または再セサ属して再試行してください。</translation>
 </phrase>
 
 <phrase>
@@ -2285,7 +2285,7 @@ Please close this file in any other running programs, then try again.</original>
 
 <phrase>
 <original>Failed to load %1</original>
-<translation>%1 をロードできませんでした</translation>
+<translation>%1 を読み込みできませんでした</translation>
 </phrase>
 
 <phrase>
@@ -2298,7 +2298,7 @@ Please use another program to save this image in a generic format (such as JPEG 
 
 %1
 
-ロードする前に、他のプログラムを使用して、この画像を一般的なフォーマット (JPEG または PNG など) で保存してください。  ありがとう!</translation>
+読み込む前に、他のプログラムを使用して、この画像を一般的なフォーマット (JPEG や PNG など) で保存してください。  ありがとう!</translation>
 </phrase>
 
 <phrase>
@@ -2313,7 +2313,7 @@ Please use another program to save this image in a generic format (such as JPEG 
 
 <phrase>
 <original>%1 of %2 images loaded successfully</original>
-<translation>%2 個中 %1 個の画像が正常にロードされました</translation>
+<translation>%2 個中 %1 個の画像が正常に読み込まれました</translation>
 </phrase>
 
 <phrase>
@@ -2321,7 +2321,7 @@ Please use another program to save this image in a generic format (such as JPEG 
 
 %1
 Please verify that these image(s) exist, and that they use a supported image format (like JPEG or PNG).  Thanks!</original>
-<translation>残念ながら、PhotoDemon は以下の画像をロードできませんでした: 
+<translation>残念ながら、PhotoDemon は以下の画像を読み込めませんでした: 
 
 %1
 これらの画像が存在し、サポートされている画像フォーマット (JPEG または PNG など) を使用していることを確認してください。  ありがとう!</translation>
@@ -2852,12 +2852,12 @@ Description: %2
 
 <phrase>
 <original>horizontal shear</original>
-<translation>水平剪断</translation>
+<translation>水平シアー</translation>
 </phrase>
 
 <phrase>
 <original>vertical shear</original>
-<translation>垂直せん断</translation>
+<translation>垂直シアー</translation>
 </phrase>
 
 <phrase>
@@ -3165,7 +3165,7 @@ In the meantime, please try saving the image to an alternate format.  You can al
 
 <phrase>
 <original>Screenshot options</original>
-<translation>スクリーンショットオプション</translation>
+<translation>スクリーンショット オプション</translation>
 </phrase>
 
 <!-- ScreenCapture.bas contains 7 phrases. 3 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
@@ -3192,7 +3192,7 @@ In the meantime, please try saving the image to an alternate format.  You can al
 
 <phrase>
 <original>An error occurred while attempting to load %1.  Please verify that the file is a valid PhotoDemon selection file.</original>
-<translation>%1 をロードしようとしてエラーが発生しました。  ファイルが有効なPhotoDemon選択ファイルであることを確認してください。</translation>
+<translation>%1 を読み込もうとしてエラーが発生しました。  ファイルが有効なPhotoDemon選択ファイルであることを確認してください。</translation>
 </phrase>
 
 <phrase>
@@ -3622,19 +3622,19 @@ Please enter a numeric value.</original>
 
 <phrase>
 <original>Download complete. Verifying file integrity</original>
-<translation>ダウンロード完了ファイルの整合性を確認</translation>
+<translation>ダウンロードが完了しました。 ファイルの整合性を確認しています</translation>
 </phrase>
 
 <phrase>
 <original>Download canceled.  (Remote server denied access.)</original>
-<translation>ダウンロードがキャンセルされました。  (リモートサーバーがアクセスを拒否しました。)</translation>
+<translation>ダウンロードがキャンセルされました。  (リモートサーバーがアクセスを拒否しました)</translation>
 </phrase>
 
 <phrase>
 <original>Unfortunately, %1 prevented PhotoDemon from directly downloading this file. (Direct downloads are sometimes mistaken as hotlinking by misconfigured servers.)
 
 You will need to manually download this file using your Internet browser.</original>
-<translation>残念ながら、%1は PhotoDemon がこのファイルを直接ダウンロードすることを妨げました。(直接ダウンロードは、時々、誤った設定のサーバによりホット リンクと間違われます)
+<translation>残念ながら、%1 は PhotoDemon がこのファイルを直接ダウンロードすることを妨げました。(直接のダウンロードは、時々、誤った設定のサーバによりホット リンクと間違われます)
 
 インターネットブラウザを使用して、このファイルを手動でダウンロードする必要があります。</translation>
 </phrase>
@@ -3766,7 +3766,7 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>Select a LUT file</original>
-<translation>LUTファイルを選択</translation>
+<translation>LUT ファイルを選択</translation>
 </phrase>
 
 <!-- pdLUT3D.cls contains 8 phrases. 5 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
@@ -4074,12 +4074,12 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>Unfortunately, the number of images you selected exceeds what Windows allows for a single load operation.  Please try again with a smaller set of images.</original>
-<translation>残念ながら、選択された画像の数は、Windowsが1回のロード操作で許容する数を超えています。  より少ない画像セットで再試行してください。</translation>
+<translation>残念ながら、選択された画像の数は、Windows が 1 回の読み込み操作で許容する数を超えています。  より少ない画像セットで再試行してください。</translation>
 </phrase>
 
 <phrase>
 <original>Load canceled.</original>
-<translation>ロードはキャンセルされました。</translation>
+<translation>読み込みはキャンセルされました。</translation>
 </phrase>
 
 <!-- pdOpenSaveDialog.cls contains 4 phrases. 2 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
@@ -4246,12 +4246,12 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>color format</original>
-<translation>カラーフォーマット</translation>
+<translation>カラー フォーマット</translation>
 </phrase>
 
 <phrase>
 <original>palette size</original>
-<translation>パレットサイズ</translation>
+<translation>パレット サイズ</translation>
 </phrase>
 
 <phrase>
@@ -4318,7 +4318,7 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>RGB(%1, %2, %3)</original>
-<translation>Rgb(%1, %2, %3)</translation>
+<translation>RGBs(%1, %2, %3)</translation>
 </phrase>
 
 <phrase>
@@ -5268,7 +5268,7 @@ The final value must be between %3 and %4.</original>
 
 <phrase>
 <original>Figured glass (dents)</original>
-<translation>フィギュアド グラス (へこみ)</translation>
+<translation>模様入りガラス (へこみ)</translation>
 </phrase>
 
 <phrase>
@@ -5308,7 +5308,7 @@ The final value must be between %3 and %4.</original>
 
 <phrase>
 <original>Dilate</original>
-<translation>広げる</translation>
+<translation>拡張</translation>
 </phrase>
 
 <phrase>
@@ -5876,7 +5876,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>new balance</original>
-<translation>ニュー バランス</translation>
+<translation>新しいバランス</translation>
 </phrase>
 
 <phrase>
@@ -5935,7 +5935,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Highest Quality (ITU Standard)</original>
-<translation>最高品質 (Itu標準)</translation>
+<translation>最高品質 (ITU 標準)</translation>
 </phrase>
 
 <phrase>
@@ -5950,7 +5950,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Single color channel</original>
-<translation>単色チャンネル</translation>
+<translation>1 つのカラー チャネル</translation>
 </phrase>
 
 <phrase>
@@ -5989,12 +5989,12 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>available LUTs</original>
-<translation>使用可能なLUT</translation>
+<translation>使用可能な LUT</translation>
 </phrase>
 
 <phrase>
 <original>import LUT file</original>
-<translation>LUTファイルのインポート</translation>
+<translation>LUT ファイルのインポート</translation>
 </phrase>
 
 <phrase>
@@ -6014,7 +6014,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Your LUT collection is stored in the "%1" folder</original>
-<translation>Lutコレクションは"%1 "フォルダに保存されます。</translation>
+<translation>LUT コレクションは "%1" フォルダに保存されます。</translation>
 </phrase>
 
 <phrase>
@@ -6075,12 +6075,12 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>warmer</original>
-<translation>ウォーマー</translation>
+<translation>暖色</translation>
 </phrase>
 
 <phrase>
 <original>cooler</original>
-<translation>クーラー</translation>
+<translation>寒色</translation>
 </phrase>
 
 <phrase>
@@ -6129,7 +6129,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>vibrance</original>
-<translation>振動</translation>
+<translation>彩度</translation>
 </phrase>
 
 <phrase>
@@ -6233,7 +6233,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>(Note: move the mouse over the histogram to calculate these values)</original>
-<translation>(注: これらの値を計算するには、ヒストグラムの上にマウスを移動してください。)</translation>
+<translation>(注: これらの値を計算するには、ヒストグラムの上にマウスを移動してください)</translation>
 </phrase>
 
 <phrase>
@@ -6344,7 +6344,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>foreground</original>
-<translation>フォアグラウンド</translation>
+<translation>前景</translation>
 </phrase>
 
 <phrase>
@@ -6354,7 +6354,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Removing haze from image</original>
-<translation>画像から霞を取り除く</translation>
+<translation>画像からかすみを取り除く</translation>
 </phrase>
 
 <!-- Adjustments_Lighting_Dehaze.frm contains 7 phrases. 4 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
@@ -6405,7 +6405,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>midpoint</original>
-<translation>中点</translation>
+<translation>中間点</translation>
 </phrase>
 
 <phrase>
@@ -6432,7 +6432,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Like all monochrome-to-grayscale tools, this tool will produce a blurry image.  You can use the Effects -> Sharpen -> Unsharp Masking tool to fix this.  (For best results, use an Unsharp Mask radius at least as large as this radius.)</original>
-<translation>他のモノクロからグレースケールへのツールと同様、このツールはぼやけた画像を生成します。  これを修正するには、 [エフェクト] -> [シャープ] -> [アンシャープ マスク] ツールを使用します。  (最良の結果を得るには、少なくともこの半径と同じ大きさのアンシャープマスク半径を使用してください)</translation>
+<translation>他のモノクロからグレースケールへのツールと同様、このツールは、ぼやけた画像を生成します。  これを修正するには、 [エフェクト] -> [シャープ] -> [アンシャープ マスク] ツールを使用します。  (最良の結果を得るには、少なくともこの半径と同じ大きさのアンシャープマスク半径を使用してください)</translation>
 </phrase>
 
 <!-- Adjustments_Monochrome_MonoToGray.frm contains 8 phrases. 4 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
@@ -6461,7 +6461,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Warming filter (%1)</original>
-<translation>ウォーム フィルター (%1)</translation>
+<translation>温暖フィルター (%1)</translation>
 </phrase>
 
 <phrase>
@@ -6471,7 +6471,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Red</original>
-<translation>レッド</translation>
+<translation>赤</translation>
 </phrase>
 
 <phrase>
@@ -6481,7 +6481,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Yellow</original>
-<translation>イエロー</translation>
+<translation>黄</translation>
 </phrase>
 
 <phrase>
@@ -6548,22 +6548,22 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>highlight color</original>
-<translation>ハイライトカラー</translation>
+<translation>ハイライト色</translation>
 </phrase>
 
 <phrase>
 <original>shadow color</original>
-<translation>シャドーカラー</translation>
+<translation>シャドー色</translation>
 </phrase>
 
 <phrase>
 <original>toning strength</original>
-<translation>引き締め力</translation>
+<translation>調色強度</translation>
 </phrase>
 
 <phrase>
 <original>Split-toning image</original>
-<translation>スプリット トーン画像</translation>
+<translation>画像の分割トーン</translation>
 </phrase>
 
 <!-- Adjustments_Photo_SplitTone.frm contains 7 phrases. 2 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
@@ -6590,7 +6590,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Adjusting shadows, midtones, and highlights</original>
-<translation>シャドー、中間調、ハイライトの調整</translation>
+<translation>シャドー・中間調・ハイライトの調整</translation>
 </phrase>
 
 <!-- Adjustments_ShadowAndHighlight.frm contains 17 phrases. 12 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
@@ -6599,7 +6599,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Autosave data detected</original>
-<translation>自動保存のデータが検出</translation>
+<translation>自動保存のデータが検出されました</translation>
 </phrase>
 
 <phrase>
@@ -7832,7 +7832,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>if pixels lie outside the image</original>
-<translation>ピクセルが画像の外側にある場合</translation>
+<translation>画素が画像の外側にある場合</translation>
 </phrase>
 
 <phrase>
@@ -7847,7 +7847,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>random seed</original>
-<translation>ランダム シード</translation>
+<translation>乱数シード</translation>
 </phrase>
 
 <phrase>
@@ -7859,7 +7859,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>shadow cut-off</original>
-<translation>シャドーカット</translation>
+<translation>シャドー カット オフ</translation>
 </phrase>
 
 <phrase>
@@ -7874,7 +7874,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>contrast midpoint</original>
-<translation>コントラスト中点</translation>
+<translation>コントラスト中間点</translation>
 </phrase>
 
 <phrase>
@@ -7908,7 +7908,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>primary angle</original>
-<translation>プライマリーアングル</translation>
+<translation>プライマリー角度</translation>
 </phrase>
 
 <phrase>
@@ -7960,7 +7960,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Applying modern art techniques</original>
-<translation>現代美術のテクニックを応用</translation>
+<translation>現代アートのテクニックを適用</translation>
 </phrase>
 
 <!-- Effects_Artistic_ModernArt.frm contains 6 phrases. 3 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
@@ -7989,7 +7989,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>light angle</original>
-<translation>ライトアングル</translation>
+<translation>ライトの角度</translation>
 </phrase>
 
 <phrase>
@@ -8040,12 +8040,12 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>cell size</original>
-<translation>セルサイズ</translation>
+<translation>セル サイズ</translation>
 </phrase>
 
 <phrase>
 <original>shading quality</original>
-<translation>シェーディングのクオリティ</translation>
+<translation>シェーディングの品質</translation>
 </phrase>
 
 <phrase>
@@ -8060,7 +8060,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>color sampling</original>
-<translation>カラーサンプリング</translation>
+<translation>カラー サンプリング</translation>
 </phrase>
 
 <phrase>
@@ -8070,7 +8070,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Carving image from stained glass</original>
-<translation>ステンドグラスから画像を彫る</translation>
+<translation>ステンド グラスから画像を彫る</translation>
 </phrase>
 
 <phrase>
@@ -8183,7 +8183,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Applying motion blur</original>
-<translation>モーションブラーの適用</translation>
+<translation>モーションぼかしの適用</translation>
 </phrase>
 
 <phrase>
@@ -8207,21 +8207,21 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Generating symmetric pixel pairs</original>
-<translation>対称ピクセルペアの生成</translation>
+<translation>対称ピクセル ペアの生成</translation>
 </phrase>
 
 <!-- Effects_Blur_SNN.frm contains 5 phrases. 4 were duplicates of existing phrases, so only one new phrase was written to file. -->
 
 <phrase>
 <original>Applying surface blur</original>
-<translation>サーフェスブラーの適用</translation>
+<translation>波紋ぼかしの適用</translation>
 </phrase>
 
 <!-- Effects_Blur_SurfaceBlur.frm contains 5 phrases. 4 were duplicates of existing phrases, so only one new phrase was written to file. -->
 
 <phrase>
 <original>Applying zoom blur</original>
-<translation>ズームブラーの適用</translation>
+<translation>ズームぼかしの適用</translation>
 </phrase>
 
 <!-- Effects_Blur_ZoomBlur.frm contains 6 phrases. 5 were duplicates of existing phrases, so only one new phrase was written to file. -->
@@ -8257,7 +8257,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>(a) edges</original>
-<translation>(エッジ</translation>
+<translation>(a) エッジ</translation>
 </phrase>
 
 <phrase>
@@ -8321,7 +8321,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>swap order</original>
-<translation>スワップオーダー</translation>
+<translation>スワップ オーダー</translation>
 </phrase>
 
 <phrase>
@@ -8336,7 +8336,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Summoning M. C. Escher</original>
-<translation>M.C.エッシャーを召喚</translation>
+<translation>M. C. エッシャーを召喚</translation>
 </phrase>
 
 <!-- Effects_Distort_Droste.frm contains 11 phrases. 7 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
@@ -8383,7 +8383,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>twist edges</original>
-<translation>ツイストエッジ</translation>
+<translation>ツイスト エッジ</translation>
 </phrase>
 
 <phrase>
@@ -8395,7 +8395,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>whirl angle</original>
-<translation>渦巻き角度</translation>
+<translation>うず巻き角度</translation>
 </phrase>
 
 <phrase>
@@ -8482,7 +8482,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>base color</original>
-<translation>ベースカラー</translation>
+<translation>ベースの色</translation>
 </phrase>
 
 <phrase>
@@ -8681,7 +8681,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Generating bump map</original>
-<translation>バンプマップの生成</translation>
+<translation>バンプ マップの生成</translation>
 </phrase>
 
 <!-- Effects_LightAndShadow_BumpMap.frm contains 12 phrases. 10 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
@@ -8698,7 +8698,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Applying cross-screen filter</original>
-<translation>クロススクリーンフィルターの適用</translation>
+<translation>クロス スクリーン フィルターの適用</translation>
 </phrase>
 
 <!-- Effects_LightAndShadow_CrossScreen.frm contains 9 phrases. 6 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
@@ -8717,7 +8717,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>randomize</original>
-<translation>ランダマイズ</translation>
+<translation>ランダム性</translation>
 </phrase>
 
 <phrase>
@@ -8744,7 +8744,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Creating artificial atmosphere</original>
-<translation>人工的な雰囲気作り</translation>
+<translation>人工的な大気</translation>
 </phrase>
 
 <!-- Effects_Nature_Atmosphere.frm contains 8 phrases. 7 were duplicates of existing phrases, so only one new phrase was written to file. -->
@@ -8865,7 +8865,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>sharpen</original>
-<translation明確化</translation>
+<translation>明確化</translation>
 </phrase>
 
 <phrase>
@@ -8889,12 +8889,12 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Generating film grain texture</original>
-<translation>フィルムグレインテクスチャの生成</translation>
+<translation>フィルム グレイン テクスチャの生成</translation>
 </phrase>
 
 <phrase>
 <original>Softening film grain</original>
-<translation>フィルムグレインを和らげる</translation>
+<translation>フィルム グレインを和らげる</translation>
 </phrase>
 
 <!-- Effects_Noise_FilmGrain.frm contains 6 phrases. 4 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
@@ -8908,7 +8908,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Applying mean shift filter</original>
-<translation>平均シフトフィルターの適用</translation>
+<translation>平均シフト フィルターの適用</translation>
 </phrase>
 
 <!-- Effects_Noise_MeanShift.frm contains 6 phrases. 5 were duplicates of existing phrases, so only one new phrase was written to file. -->
@@ -8920,17 +8920,17 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Applying erode (minimum rank) filter</original>
-<translation>erode (最小ランク)フィルターの適用</translation>
+<translation>浸食 (最小ランク) フィルターの適用</translation>
 </phrase>
 
 <phrase>
 <original>Applying dilate (maximum rank) filter</original>
-<translation>ディレート (最大ランク)フィルターの適用</translation>
+<translation>拡張 (最大ランク) フィルターの適用</translation>
 </phrase>
 
 <phrase>
 <original>Applying median filter</original>
-<translation>メディアンフィルターの適用</translation>
+<translation>中心値フィルターの適用</translation>
 </phrase>
 
 <!-- Effects_Noise_MedianSmoothing.frm contains 15 phrases. 11 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
@@ -8947,12 +8947,12 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>yellow angle</original>
-<translation>イエローアングル</translation>
+<translation>イエロー角</translation>
 </phrase>
 
 <phrase>
 <original>Printing image to digital halftone surface</original>
-<translation>デジタル網点画面への印刷</translation>
+<translation>デジタル ハーフトーン面で画像を印刷しています</translation>
 </phrase>
 
 <!-- Effects_Pixelate_ColorHalftone.frm contains 8 phrases. 4 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
@@ -9210,12 +9210,12 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>median cut</original>
-<translation>メディアンカット</translation>
+<translation>メディアン カット</translation>
 </phrase>
 
 <phrase>
 <original>neural network</original>
-<translation>ニューラルネットワーク</translation>
+<translation>ニューラル ネットワーク</translation>
 </phrase>
 
 <phrase>
@@ -10254,7 +10254,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>full download path (must begin with "http://" or "ftp://")</original>
-<translation>完全なダウンロードパス ("http://" または "ftp://" で始まる必要があります。)</translation>
+<translation>完全なダウンロードパス ("http://" または "ftp://" で始まる必要があります)</translation>
 </phrase>
 
 <phrase>
@@ -10296,12 +10296,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>include window decorations</original>
-<translation>ウィンドウ装飾を含む</translation>
+<translation>ウィンドウの装飾を含む</translation>
 </phrase>
 
 <phrase>
 <original>minimize PhotoDemon prior to capture</original>
-<translation>撮影前に PhotoDemon を最小化</translation>
+<translation>キャプチャ前に PhotoDemon を最小化</translation>
 </phrase>
 
 <phrase>
@@ -10331,29 +10331,29 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>This program is currently minimized.  Restore it to normal size for best results.</original>
-<translation>このプログラムは現在最小化されています。  最良の結果を得るためには、通常のサイズに戻してください。</translation>
+<translation>このプログラムは現在最小化されています。  最適な結果を得るためには、通常のサイズに戻してください。</translation>
 </phrase>
 
 <phrase>
 <original>Some programs (including Windows Store apps) do not allow direct screen captures.  If an application preview appears as a black square, you will need to take a full desktop screenshot, then manually crop the desired window region.</original>
-<translation>一部のプログラム (Windowsストアアプリを含む)では、画面を直接キャプチャすることができません。  アプリケーションのプレビューが黒い四角で表示される場合は、デスクトップ全体のスクリーンショットを撮影し、必要なウィンドウ領域を手動でトリミングする必要があります。</translation>
+<translation>一部のプログラム (Windowsストアアプリを含む) では、画面を直接キャプチャすることができません。  アプリケーションのプレビューが黒い四角で表示される場合は、デスクトップ全体のスクリーンショットを撮影し、必要なウィンドウ領域を手動でトリミングする必要があります。</translation>
 </phrase>
 
 <phrase>
 <original>Unfortunately, that program has exited.</original>
-<translation>残念ながら、そのプログラムは終了してしまった。</translation>
+<translation>残念ながら、そのプログラムは終了しました。</translation>
 </phrase>
 
 <phrase>
 <original>Please select another one.</original>
-<translation>他をお選びください。</translation>
+<translation>別のものを選択してください。</translation>
 </phrase>
 
 <!-- File_Import_ScreenCapture.frm contains 22 phrases. 10 were duplicates of existing phrases, so only 12 new phrases were written to file. -->
 
 <phrase>
 <original>transparent</original>
-<translation>透明</translation>
+<translation>透過</translation>
 </phrase>
 
 <phrase>
@@ -11347,7 +11347,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>when changing aspect ratio, fit image to new size by</original>
-<translation>アスペクト比を変更する場合は、次の方法で画像を新しいサイズに合わせる</translation>
+<translation>アスペクト比を変更する場合、次の方法で新しいサイズに合わせる</translation>
 </phrase>
 
 <phrase>
@@ -12209,7 +12209,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>spiral</original>
-<translation>渦巻き</translation>
+<translation>うず巻き</translation>
 </phrase>
 
 <!-- Toolpanel_Gradient.frm contains 19 phrases. 13 were duplicates of existing phrases, so only 6 new phrases were written to file. -->
@@ -12521,7 +12521,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>click to edit text</original>
-<translation>クリックしてテキストを編集</translation>
+<translation>クリックでテキストを編集</translation>
 </phrase>
 
 <phrase>

--- a/App/PhotoDemon/Languages/Japanese.xml
+++ b/App/PhotoDemon/Languages/Japanese.xml
@@ -2215,7 +2215,7 @@ To enable support for this image format, please copy the FreeImage.dll file (dow
 
 <phrase>
 <original>In the future, automatically rasterize without prompting me</original>
-<translation>今後は、プロンプトを表示せずに自動的にラスタライズします</translation>
+<translation>今後、プロンプトを表示せずに自動的にラスタライズする</translation>
 </phrase>
 
 <phrase>
@@ -2294,11 +2294,11 @@ Please close this file in any other running programs, then try again.</original>
 %1
 
 Please use another program to save this image in a generic format (such as JPEG or PNG) before loading it.  Thanks!</original>
-<translation>残念ながら、PhotoDemon は以下の画像を読み込むことができませんでした: 
+<translation>残念ながら、PhotoDemon は以下の画像を読み込むことができませんでした:
 
 %1
 
-読み込む前に、他のプログラムを使用して、この画像を一般的なフォーマット (JPEG や PNG など) で保存してください。  ありがとう!</translation>
+読み込む前に、他のプログラムを使用して、この画像を一般的なフォーマット (JPEG または PNG など) で保存してください。 ありがとう!</translation>
 </phrase>
 
 <phrase>
@@ -2321,10 +2321,11 @@ Please use another program to save this image in a generic format (such as JPEG 
 
 %1
 Please verify that these image(s) exist, and that they use a supported image format (like JPEG or PNG).  Thanks!</original>
-<translation>残念ながら、PhotoDemon は以下の画像を読み込めませんでした: 
+<translation>残念ながら、PhotoDemon は以下の画像を読み込むことができませんでした:
 
 %1
-これらの画像が存在し、サポートされている画像フォーマット (JPEG または PNG など) を使用していることを確認してください。  ありがとう!</translation>
+
+これらの画像が存在すること、およびサポートされている画像形式 (JPEG や PNG など) を使用していることを確認してください。  ありがとう!</translation>
 </phrase>
 
 <phrase>
@@ -2448,17 +2449,17 @@ Please verify that these image(s) exist, and that they use a supported image for
 
 <phrase>
 <original>Adobe Color Swatch</original>
-<translation>アドビ カラー スウォッチ</translation>
+<translation>Adobe カラー スウォッチ</translation>
 </phrase>
 
 <phrase>
 <original>Adobe Color Table</original>
-<translation>アドビ カラー テーブル</translation>
+<translation>Adobe カラー テーブル</translation>
 </phrase>
 
 <phrase>
 <original>Adobe Swatch Exchange</original>
-<translation>アドビ スウォッチ エクスチェンジ</translation>
+<translation>Adobe 交換用スウォッチ</translation>
 </phrase>
 
 <phrase>
@@ -2503,12 +2504,12 @@ Please verify that these image(s) exist, and that they use a supported image for
 
 <phrase>
 <original>Ordered (Bayer 4x4)</original>
-<translation>オーダー (バイエル4x4)</translation>
+<translation>オーダー (ベイヤー 4x4)</translation>
 </phrase>
 
 <phrase>
 <original>Ordered (Bayer 8x8)</original>
-<translation>オーダー (バイエル8x8)</translation>
+<translation>オーダー (ベイヤー 8x8)</translation>
 </phrase>
 
 <phrase>
@@ -2533,7 +2534,7 @@ Please verify that these image(s) exist, and that they use a supported image for
 
 <phrase>
 <original>Atkinson / Classic Macintosh</original>
-<translation>アトキンソン / クラシック・マッキントッシュ</translation>
+<translation>アトキンソン / クラシック マッキントッシュ</translation>
 </phrase>
 
 <!-- Palettes.bas contains 48 phrases. 29 were duplicates of existing phrases, so only 19 new phrases were written to file. -->
@@ -2547,17 +2548,17 @@ Please verify that these image(s) exist, and that they use a supported image for
 
 <phrase>
 <original>AVIF is a modern image format developed by the Alliance for Open Media.  PhotoDemon does not natively support AVIF images, but it can download a free, open-source plugin that permanently enables AVIF support.</original>
-<translation>AVIF は、Alliance for Open Mediaによって開発された最新の画像フォーマットです。  PhotoDemon は、ネイティブで AVIF 画像をサポートしていませんが、AVIF サポートを永続的に有効にする無料のオープン ソース プラグインをダウンロードできます。</translation>
+<translation>AVIF は、Alliance for Open Media によって開発された最新の画像フォーマットです。  PhotoDemon は、ネイティブで AVIF 画像をサポートしていませんが、AVIF サポートを永続的に有効にする無料のオープン ソース プラグインをダウンロードできます。</translation>
 </phrase>
 
 <phrase>
 <original>The Alliance for Open Media provides free, open-source 64-bit AVIF encoder and decoder libraries.  These libraries are roughly ~%1 mb each (~%2 mb total).  Once downloaded, they will allow PhotoDemon to import and export AVIF files on any 64-bit system.</original>
-<translation>Alliance for Open Media は、フリーでオープンソースの64ビットAVIFエンコーダーとデコーダー ライブラリを提供しています。  これらのライブラリは、それぞれ約 ~%1 mb (合計 ~%2 mb) です。  ダウンロードすると、PhotoDemon が 64 ビットシステム上で AVIF ファイルをインポートおよびエクスポートできるようになります。</translation>
+<translation>Alliance for Open Media は、フリーでオープン ソースの 64 ビット AVIF エンコーダーとデコーダー ライブラリを提供しています。  これらのライブラリは、それぞれ約 ~%1 mb (合計 ~%2 mb) です。  ダウンロードすると、PhotoDemon が 64 ビットシステム上で AVIF ファイルをインポートおよびエクスポートできるようになります。</translation>
 </phrase>
 
 <phrase>
 <original>Would you like PhotoDemon to download these libraries to your PhotoDemon plugin folder?</original>
-<translation>PhotoDemon がこれらのライブラリを PhotoDemon プラグイン フォルダにダウンロードしますか?</translation>
+<translation>PhotoDemon でこれらのライブラリを PhotoDemon プラグイン フォルダにダウンロードしますか?</translation>
 </phrase>
 
 <phrase>
@@ -2587,28 +2588,28 @@ Please verify that these image(s) exist, and that they use a supported image for
 
 <phrase>
 <original>You have placed PhotoDemon in a restricted system folder.  Because PhotoDemon does not have administrator access, it cannot download files for you.  Please move PhotoDemon to an unrestricted folder and try again.</original>
-<translation>制限されたシステムフォルダに PhotoDemon を配置しました。  PhotoDemon は管理者権限を持っていないため、ファイルをダウンロードすることができません。  PhotoDemon を制限のないフォルダに移動し、再度お試しください。</translation>
+<translation>制限されたシステムフォルダに PhotoDemon を配置しました。  PhotoDemon は管理者権限を持っていないため、ファイルをダウンロードすることができません。  PhotoDemon を制限のないフォルダに移動し、もう一度お試しください。</translation>
 </phrase>
 
 <!-- Plugin_AVIF.bas contains 16 phrases. 7 were duplicates of existing phrases, so only 9 new phrases were written to file. -->
 
 <phrase>
 <original>Scanner successfully enabled</original>
-<translation>スキャナは正常に有効化されました</translation>
+<translation>スキャナーは正常に有効化されました</translation>
 </phrase>
 
 <phrase>
 <original>The selected scanner or digital camera isn't responding.
 
 Please make sure the device is turned on and ready for use.</original>
-<translation>選択したスキャナまたはデジタルカメラが応答しません。
+<translation>選択したスキャナーまたはデジタルカメラが応答しません。
 
 デバイスの電源が入っており、使用できる状態であることを確認してください。</translation>
 </phrase>
 
 <phrase>
 <original>Scanner error</original>
-<translation>スキャナーエラー</translation>
+<translation>スキャナー エラー</translation>
 </phrase>
 
 <phrase>
@@ -2617,7 +2618,7 @@ Please make sure the device is turned on and ready for use.</original>
 To enable scanner support, please copy the EZTW32.dll file (available for download from http://eztwain.com/ezt1_download.htm) into the plug-in directory and reload the program.</original>
 <translation>プログラムの初期化時に、スキャナー/デジタルカメラインターフェースプラグイン (EZTW32.Dll) が見つからないとマークされました。
 
-スキャナサポートを有効にするには、EZTW32.Dll ファイル (http://eztwain.com/ezt1_download.htm からダウンロード可能)をプラグインディレクトリにコピーし、プログラムを再読み込みしてください。</translation>
+スキャナーサポートを有効にするには、EZTW32.Dll ファイル (http://eztwain.com/ezt1_download.htm からダウンロード可能)をプラグインディレクトリにコピーし、プログラムを再読み込みしてください。</translation>
 </phrase>
 
 <phrase>
@@ -2637,7 +2638,7 @@ To enable scanner support, please copy the EZTW32.dll file (available for downlo
 
 <phrase>
 <original>Unknown error occurred.  Please make sure your scanner is turned on and ready for use.</original>
-<translation>不明なエラーが発生しました。  スキャナの電源が入っており、使用可能な状態であることを確認してください。</translation>
+<translation>不明なエラーが発生しました。  スキャナーの電源が入っており、使用可能な状態であることを確認してください。</translation>
 </phrase>
 
 <phrase>
@@ -2647,7 +2648,7 @@ To enable scanner support, please copy the EZTW32.dll file (available for downlo
 
 <phrase>
 <original>Unable to acquire DIB lock.  Please make sure no other programs are accessing the scanner.  If the problem persists, reboot and try again.</original>
-<translation>DIB ロックを取得できません。  他のプログラムがスキャナにアクセスしていないことを確認してください。  問題が解決しない場合は、再起動して再度お試しください。</translation>
+<translation>DIB ロックを取得できません。  他のプログラムがスキャナーにアクセスしていないことを確認してください。  問題が解決しない場合は、再起動して再度お試しください。</translation>
 </phrase>
 
 <phrase>
@@ -2667,7 +2668,7 @@ To enable scanner support, please copy the EZTW32.dll file (available for downlo
 
 <phrase>
 <original>The scanner returned an error code that wasn't specified in the EZTW32.dll documentation (Error #%1).  Please visit http://www.eztwain.com for more information.</original>
-<translation>スキャナは、EZTW32.dll ドキュメントで指定されていないエラーコードを返しました (エラー #%1)。  詳しくは http://www.eztwain.com をご参照ください。</translation>
+<translation>スキャナーは、EZTW32.dll ドキュメントで指定されていないエラーコードを返しました (エラー #%1)。  詳しくは http://www.eztwain.com をご参照ください。</translation>
 </phrase>
 
 <!-- Plugin_EZTwain.bas contains 32 phrases. 18 were duplicates of existing phrases, so only 14 new phrases were written to file. -->
@@ -4002,7 +4003,7 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>XMP (Adobe SWF)</original>
-<translation>XMP (アドビswf)</translation>
+<translation>XMP (Adobeswf)</translation>
 </phrase>
 
 <phrase>

--- a/App/PhotoDemon/Languages/Japanese.xml
+++ b/App/PhotoDemon/Languages/Japanese.xml
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
-
+﻿<?xml version='1.0' encoding='UTF-8'?>
 <pdData>
 
 <pdDataType>Translation</pdDataType>
@@ -7,7 +6,7 @@
 <langid>ja-JP</langid>
 <langname>日本語 (Japanese)</langname>
 <langversion>1.0.0</langversion>
-<langstatus>95% complete</langstatus>
+<langstatus>Complete</langstatus>
 
 <author>Kenji Hoshimoto (Hosiken)</author>
 
@@ -1434,7 +1433,7 @@
 
 <phrase>
 <original>The tag database handles technical details of the 20,000+ metadata tags supported by PhotoDemon.  Creating the database takes 10 to 15 seconds, and it only needs to be created once, when the metadata editor is used for the first time.</original>
-<translation>タグ データベースは、PhotoDemon でサポートされている 20,000 以上のメタデータ タグの技術的な詳細を処理します。  データベースの作成には 10 から 15 秒かかります。  作成する必要があるのは、メタデータ エディタを初めて使用するときに 1 回だけです。</translation>
+<translation>タグ データベースは、PhotoDemon でサポートされている 20,000 以上のメタデータ タグの技術的な詳細を処理します。  データベースの作成には 10 から 15 秒かかります。  作成する必要があるのは、メタデータ エディターを初めて使用するときに 1 回だけです。</translation>
 </phrase>
 
 <phrase>
@@ -1509,7 +1508,7 @@ If the problem persists, please report it to the PhotoDemon developers via Photo
 
 <phrase>
 <original>Unfortunately, this PC does not have enough memory to create a %1x%2 image.  Please reduce the requested size and try again.</original>
-<translation>残念ながら、この PC には %1x%2 の画像を作成するのに十分なメモリがありません。  要求されたサイズを小さくして再試行してください。</translation>
+<translation>残念ながら、この PC には %1x%2 の画像を作成するのに十分なメモリーがありません。  要求されたサイズを小さくして再試行してください。</translation>
 </phrase>
 
 <phrase>
@@ -1797,8 +1796,8 @@ This image contains %2 unique color + opacity values (RGBA).</original>
 </phrase>
 
 <phrase>
-<original>%1 save failed. Please report this error using Help -> Submit Bug Report.</original>
-<translation>%1 の保存に失敗しました。 [ヘルプ] -> [バグ レポートまたはフィードバックの提出] を使用してこのエラーを報告してください。</translation>
+<original>%1 save failed. Please report this error using Help -&gt; Submit Bug Report.</original>
+<translation>%1 の保存に失敗しました。 [ヘルプ] -&gt; [バグ レポートまたはフィードバックの提出] を使用してこのエラーを報告してください。</translation>
 </phrase>
 
 <phrase>
@@ -2185,17 +2184,17 @@ To enable support for this image format, please copy the FreeImage.dll file (dow
 
 <phrase>
 <original>Are you sure you want to continue?</original>
-<translation>本当に続けるのか?</translation>
+<translation>続行してもよろしいですか?</translation>
 </phrase>
 
 <phrase>
 <original>Yes.  Convert text and vector layers to image (raster) layers.</original>
-<translation>はい。  テキスト レイヤーとベクター レイヤーをイメージ (ラスター) レイヤーに変換します。</translation>
+<translation>はい。  テキスト レイヤーとベクター レイヤーを画像 (ラスター) レイヤーに変換します。</translation>
 </phrase>
 
 <phrase>
 <original>No.  Leave text and vector layers as they are.</original>
-<translation>いいえ、テキストとベクター レイヤーはそのままにしておきます。</translation>
+<translation>いいえ。  テキスト レイヤーとベクター レイヤーはそのままにしておきます。</translation>
 </phrase>
 
 <phrase>
@@ -2215,7 +2214,7 @@ To enable support for this image format, please copy the FreeImage.dll file (dow
 
 <phrase>
 <original>In the future, automatically rasterize without prompting me</original>
-<translation>今後、プロンプトを表示せずに自動的にラスタライズする</translation>
+<translation>今後は、確認せずに自動的にラスタライズする</translation>
 </phrase>
 
 <phrase>
@@ -2237,7 +2236,7 @@ To enable support for this image format, please copy the FreeImage.dll file (dow
 
 <phrase>
 <original>Loading image</original>
-<translation>画像を読み込んでいます</translation>
+<translation>画像を読み込み中</translation>
 </phrase>
 
 <phrase>
@@ -2335,7 +2334,7 @@ Please verify that these image(s) exist, and that they use a supported image for
 
 <phrase>
 <original>Duplicating current image</original>
-<translation>現在の画像を複製</translation>
+<translation>現在の画像を複製しています</translation>
 </phrase>
 
 <phrase>
@@ -2444,7 +2443,7 @@ Please verify that these image(s) exist, and that they use a supported image for
 
 <phrase>
 <original>All supported palettes</original>
-<translation>すべてのサポートパレット</translation>
+<translation>サポートされているすべてのパレット</translation>
 </phrase>
 
 <phrase>
@@ -2534,7 +2533,7 @@ Please verify that these image(s) exist, and that they use a supported image for
 
 <phrase>
 <original>Atkinson / Classic Macintosh</original>
-<translation>アトキンソン / クラシック マッキントッシュ</translation>
+<translation>アトキンソン / クラシック Macintosh</translation>
 </phrase>
 
 <!-- Palettes.bas contains 48 phrases. 29 were duplicates of existing phrases, so only 19 new phrases were written to file. -->
@@ -2552,13 +2551,13 @@ Please verify that these image(s) exist, and that they use a supported image for
 </phrase>
 
 <phrase>
-<original>The Alliance for Open Media provides free, open-source 64-bit AVIF encoder and decoder libraries.  These libraries are roughly ~%1 mb each (~%2 mb total).  Once downloaded, they will allow PhotoDemon to import and export AVIF files on any 64-bit system.</original>
-<translation>Alliance for Open Media は、フリーでオープン ソースの 64 ビット AVIF エンコーダーとデコーダー ライブラリを提供しています。  これらのライブラリは、それぞれ約 ~%1 mb (合計 ~%2 mb) です。  ダウンロードすると、PhotoDemon が 64 ビットシステム上で AVIF ファイルをインポートおよびエクスポートできるようになります。</translation>
+<original>The Alliance for Open Media provides free, open-source 64-bit AVIF encoder and decoder libraries.  These libraries are roughly &#126;%1 mb each (&#126;%2 mb total).  Once downloaded, they will allow PhotoDemon to import and export AVIF files on any 64-bit system.</original>
+<translation>Alliance for Open Media は、フリーでオープン ソースの 64 ビット AVIF エンコーダーとデコーダー ライブラリを提供しています。  これらのライブラリは、それぞれ約 &#126;%1 mb (合計 &#126;%2 mb) です。  ダウンロードすると、PhotoDemon が 64 ビットシステム上で AVIF ファイルをインポートおよびエクスポートできるようになります。</translation>
 </phrase>
 
 <phrase>
 <original>Would you like PhotoDemon to download these libraries to your PhotoDemon plugin folder?</original>
-<translation>PhotoDemon でこれらのライブラリを PhotoDemon プラグイン フォルダにダウンロードしますか?</translation>
+<translation>PhotoDemon でこれらのライブラリを PhotoDemon プラグイン フォルダーにダウンロードしますか?</translation>
 </phrase>
 
 <phrase>
@@ -2573,7 +2572,7 @@ Please verify that these image(s) exist, and that they use a supported image for
 
 <phrase>
 <original>To manually enable AVIF support, you can download the latest copies of the free "%1" and "%2" programs and place them into your PhotoDemon plugin folder</original>
-<translation>手動で AVIF サポートを有効にするには、無料の「%1」および「%2」プログラムの最新コピーをダウンロードし、PhotoDemon プラグイン フォルダに配置します。</translation>
+<translation>手動で AVIF サポートを有効にするには、無料の「%1」および「%2」プログラムの最新コピーをダウンロードし、PhotoDemon プラグイン フォルダーに配置します。</translation>
 </phrase>
 
 <phrase>
@@ -2588,7 +2587,7 @@ Please verify that these image(s) exist, and that they use a supported image for
 
 <phrase>
 <original>You have placed PhotoDemon in a restricted system folder.  Because PhotoDemon does not have administrator access, it cannot download files for you.  Please move PhotoDemon to an unrestricted folder and try again.</original>
-<translation>制限されたシステムフォルダに PhotoDemon を配置しました。  PhotoDemon は管理者権限を持っていないため、ファイルをダウンロードすることができません。  PhotoDemon を制限のないフォルダに移動し、もう一度お試しください。</translation>
+<translation>制限されたシステムフォルダーに PhotoDemon を配置しました。  PhotoDemon は管理者権限を持っていないため、ファイルをダウンロードすることができません。  PhotoDemon を制限のないフォルダーに移動し、もう一度お試しください。</translation>
 </phrase>
 
 <!-- Plugin_AVIF.bas contains 16 phrases. 7 were duplicates of existing phrases, so only 9 new phrases were written to file. -->
@@ -2643,7 +2642,7 @@ To enable scanner support, please copy the EZTW32.dll file (available for downlo
 
 <phrase>
 <original>Scan successful, but temporary file save failed.  Is it possible that your hard drive is full (or almost full)?</original>
-<translation>スキャンは成功しましたが、一時ファイルの保存に失敗しました。  ハードディスクが一杯 (またはほぼ一杯)になっている可能性はありませんか?</translation>
+<translation>スキャンは成功しましたが、一時ファイルの保存に失敗しました。  ハード ディスクが (ほぼ) いっぱいになっている可能性はありませんか?</translation>
 </phrase>
 
 <phrase>
@@ -2653,7 +2652,7 @@ To enable scanner support, please copy the EZTW32.dll file (available for downlo
 
 <phrase>
 <original>Temporary file access error.  This can be caused when running on a system with limited access rights.  Please enable admin rights and try again.</original>
-<translation>一時ファイルアクセスエラー。  これは、アクセス権が制限されたシステムで実行すると発生する可能性があります。  管理者権限を有効にして再度お試しください。</translation>
+<translation>一時ファイル アクセス エラー。  これは、アクセス権が制限されたシステムで実行すると発生する可能性があります。 管理者権限を有効にして再度お試しください。</translation>
 </phrase>
 
 <phrase>
@@ -2675,7 +2674,7 @@ To enable scanner support, please copy the EZTW32.dll file (available for downlo
 
 <phrase>
 <original>Import via FreeImage failed (Err # %1)</original>
-<translation>Freeimage でのインポートに失敗しました (エラー番号 %1)。</translation>
+<translation>FreeImage 経由のインポートが失敗しました (エラー # %1)</translation>
 </phrase>
 
 <phrase>
@@ -2724,7 +2723,7 @@ To enable scanner support, please copy the EZTW32.dll file (available for downlo
 
 <phrase>
 <original>Image successfully sent to Windows Photo Printer.</original>
-<translation>Windows Photo Printer に画像が正常に送信されました。</translation>
+<translation>画像は Windows フォト プリンターに正常に送信されました。</translation>
 </phrase>
 
 <!-- Printing.bas contains 2 phrases.  Both phrases were unique, so 2 new phrases were written to file. -->
@@ -2732,38 +2731,38 @@ To enable scanner support, please copy the EZTW32.dll file (available for downlo
 <phrase>
 <original>Unknown processor request submitted: %1
 
-Please report this bug via the Help -> Submit Bug Report menu.</original>
+Please report this bug via the Help -&gt; Submit Bug Report menu.</original>
 <translation>不明なプロセッサ要求が送信されました: %1
 
-Help -> Submit Bug Report メニューからこのバグを報告してください。</translation>
+[ヘルプ] -&gt; [バグ レポートまたはフィードバックの提出] メニューからこのバグを報告してください。</translation>
 </phrase>
 
 <phrase>
 <original>There is not enough memory available to continue this operation.  Please free up system memory (RAM) by shutting down unneeded programs - especially your web browser, if it is open - then try the action again.</original>
-<translation>この操作を続行するのに十分なメモリがありません。  不要なプログラム (特にウェブブラウザを開いている場合)をシャットダウンして、システムメモリ (RAM)を解放してから、操作をやり直してください。</translation>
+<translation>この操作を続行するのに十分なメモリーがありません。 不要なプログラム (特にウェブ ブラウザを開いている場合) をシャットダウンして、システムメモリー (RAM) を解放してから、操作をやり直してください。</translation>
 </phrase>
 
 <phrase>
 <original>Out of memory.  Function canceled.</original>
-<translation>メモリ不足。  機能がキャンセルされました。</translation>
+<translation>メモリー不足です。  機能がキャンセルされました。</translation>
 </phrase>
 
 <phrase>
 <original>The specified file could not be located.  If it was located on removable media, please re-insert the proper floppy disk, CD, or portable drive.  If the file is not located on portable media, make sure that:
 1) the file hasn't been deleted, and...
 2) the file location provided to PhotoDemon is correct.</original>
-<translation>指定されたファイルが見つかりません。  リムーバブルメディアにある場合は、適切なフロッピーディスク、CD、またはポータブルドライブを挿入し直してください。  ファイルがポータブルメディアにない場合、以下のことを確認してください: 
-1) ファイルが削除されていないこと。
-2) PhotoDemonに提供されたファイルの場所が正しい。</translation>
+<translation>指定されたファイルが見つかりませんでした。  リムーバブル メディア上にある場合は、適切なフロッピー ディスク、CD、またはポータブル ドライブを再度挿入してください。  ファイルがポータブル メディアにない場合は、次のことを確認してください。
+1) ファイルが削除されてない。
+2) PhotoDemon に指定したファイルの場所が正しい。</translation>
 </phrase>
 
 <phrase>
 <original>PhotoDemon cannot locate additional information for this error.  That probably means this error is a bug, and it needs to be fixed!
 
 Would you like to submit a bug report?  (It takes less than one minute, and it helps everyone who uses the software.)</original>
-<translation>PhotoDemon は、このエラーの追加情報を見つけることができません。  それは、おそらくこのエラーがバグであり、修正される必要があることを意味します!
+<translation>PhotoDemon では、このエラーに関する追加情報が見つかりません。 おそらく、このエラーはバグであり、修正する必要があることを意味します。
 
-バグ レポートを提出しますか?  (それは1分もかからず、ソフトウェアを使用するすべての人の助けになります)</translation>
+バグレポートを送信しますか? (所要時間は 1 分もかからず、ソフトウェアを使用するすべての人に役立ちます。)</translation>
 </phrase>
 
 <phrase>
@@ -2778,7 +2777,7 @@ Error number %1
 Description: %2
 
 %3</original>
-<translation>PhotoDemonにエラーが発生しました。  問題の詳細は以下の通りです: 
+<translation>PhotoDemon でエラーが発生しました。  問題の詳細は次のとおりです。
 
 エラー番号 %1
 説明: %2
@@ -2788,7 +2787,7 @@ Description: %2
 
 <phrase>
 <original>seconds</original>
-<translation>おかわり</translation>
+<translation>秒</translation>
 </phrase>
 
 <phrase>
@@ -2873,7 +2872,7 @@ Description: %2
 
 <phrase>
 <original>font (color)</original>
-<translation>フォント(色)</translation>
+<translation>フォント (色)</translation>
 </phrase>
 
 <phrase>
@@ -2918,12 +2917,12 @@ Description: %2
 
 <phrase>
 <original>horizontal alignment</original>
-<translation>水平揃え</translation>
+<translation>水平方向の配置</translation>
 </phrase>
 
 <phrase>
 <original>vertical alignment</original>
-<translation>垂直揃え</translation>
+<translation>垂直方向の配置</translation>
 </phrase>
 
 <phrase>
@@ -2958,7 +2957,7 @@ Description: %2
 
 <phrase>
 <original>fill style</original>
-<translation>塗りつぶし スタイル</translation>
+<translation>塗りつぶしスタイル</translation>
 </phrase>
 
 <phrase>
@@ -2978,12 +2977,12 @@ Description: %2
 
 <phrase>
 <original>background border</original>
-<translation>背景のボーダー</translation>
+<translation>背景の境界線</translation>
 </phrase>
 
 <phrase>
 <original>background border style</original>
-<translation>背景のボーダー スタイル</translation>
+<translation>背景の境界線のスタイル</translation>
 </phrase>
 
 <phrase>
@@ -2998,7 +2997,7 @@ Description: %2
 
 <phrase>
 <original>character remapping</original>
-<translation>文字のリマッピング</translation>
+<translation>文字の再マッピング</translation>
 </phrase>
 
 <phrase>
@@ -3023,7 +3022,7 @@ Description: %2
 
 <phrase>
 <original>inflation</original>
-<translation>インフレ</translation>
+<translation>インフレーション</translation>
 </phrase>
 
 <phrase>
@@ -3059,7 +3058,7 @@ When finished, click the Submit New Issue button.  Thank you!</original>
 
 <phrase>
 <original>automatic</original>
-<translation>オート</translation>
+<translation>自動</translation>
 </phrase>
 
 <phrase>
@@ -3109,22 +3108,22 @@ When finished, click the Submit New Issue button.  Thank you!</original>
 
 %1
 
-In the meantime, please try saving the image to an alternate format.  You can also let the PhotoDemon developers know about this via the Help > Submit Bug Report menu.</original>
-<translation>この画像を保存しようとするとエラーが発生しました。  FreeImage プラグインは以下のエラー詳細を報告しました: 
+In the meantime, please try saving the image to an alternate format.  You can also let the PhotoDemon developers know about this via the Help &gt; Submit Bug Report menu.</original>
+<translation>この画像を保存しようとしたときにエラーが発生しました。  FreeImage プラグインは、次のエラーの詳細を報告しました:
 
 %1
 
-とりあえず、画像を別のフォーマットに保存してみてください。  また、PhotoDemon の開発者に、[ヘルプ] > [バグ レポートまたはフィードバックの提出] メニューからこのことを知らせることができます。</translation>
+それまでの間、画像を別の形式で保存してみてください。  [ヘルプ] &gt; [バグ レポートまたはフィードバックの提出] メニューから、PhotoDemon 開発者にこのことを知らせることもできます。</translation>
 </phrase>
 
 <phrase>
-<original>Output format not recognized.  Save aborted.  Please use the Help -> Submit Bug Report menu item to report this incident.</original>
-<translation>出力形式が認識されません。  保存が中断されました。  [ヘルプ] -> [バグ レポートまたはフィードバックの提出] メニュー項目を使用して、この事象を報告してください。</translation>
+<original>Output format not recognized.  Save aborted.  Please use the Help -&gt; Submit Bug Report menu item to report this incident.</original>
+<translation>出力形式が認識されません。  保存が中断されました。  この事象を報告するには、[ヘルプ] -&gt; [バグ レポートまたはフィードバックの提出] メニュー項目を使用してください。</translation>
 </phrase>
 
 <phrase>
 <original>Saving %1 image</original>
-<translation>%1 画像の保存</translation>
+<translation>%1 個の画像を保存しています</translation>
 </phrase>
 
 <phrase>
@@ -3151,7 +3150,7 @@ In the meantime, please try saving the image to an alternate format.  You can al
 
 <phrase>
 <original>Capturing screen</original>
-<translation>画面のキャプチャ</translation>
+<translation>画面のキャプチャ中</translation>
 </phrase>
 
 <phrase>
@@ -3161,12 +3160,12 @@ In the meantime, please try saving the image to an alternate format.  You can al
 
 <phrase>
 <original>Screen capture complete.</original>
-<translation>スクリーンキャプチャを完了しました。</translation>
+<translation>画面キャプチャが完了しました。</translation>
 </phrase>
 
 <phrase>
 <original>Screenshot options</original>
-<translation>スクリーンショット オプション</translation>
+<translation>スクリーンショットのオプション</translation>
 </phrase>
 
 <!-- ScreenCapture.bas contains 7 phrases. 3 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
@@ -3178,7 +3177,7 @@ In the meantime, please try saving the image to an alternate format.  You can al
 
 <phrase>
 <original>Export selection as image</original>
-<translation>選択部分を画像としてエクスポート</translation>
+<translation>選択範囲を画像としてエクスポート</translation>
 </phrase>
 
 <phrase>
@@ -3193,12 +3192,12 @@ In the meantime, please try saving the image to an alternate format.  You can al
 
 <phrase>
 <original>An error occurred while attempting to load %1.  Please verify that the file is a valid PhotoDemon selection file.</original>
-<translation>%1 を読み込もうとしてエラーが発生しました。  ファイルが有効なPhotoDemon選択ファイルであることを確認してください。</translation>
+<translation>%1 を読み込もうとしたときにエラーが発生しました。  ファイルが有効な PhotoDemon 選択ファイルであることを確認してください。</translation>
 </phrase>
 
 <phrase>
 <original>Loading selection</original>
-<translation>選択範囲の読み込み</translation>
+<translation>選択内容を読み込んでいます</translation>
 </phrase>
 
 <phrase>
@@ -3274,12 +3273,12 @@ In the meantime, please try saving the image to an alternate format.  You can al
 
 <phrase>
 <original>Release the mouse button to complete the lasso selection</original>
-<translation>マウスボタンを離すと、投げ縄の選択が完了します。</translation>
+<translation>マウスのボタンを放すと、投げ縄選択を完了します。</translation>
 </phrase>
 
 <phrase>
 <original>Move selection</original>
-<translation>移動選択</translation>
+<translation>選択範囲の移動</translation>
 </phrase>
 
 <phrase>
@@ -3300,7 +3299,7 @@ In the meantime, please try saving the image to an alternate format.  You can al
 <original>%1 is not a valid entry.
 Please enter a value between %2 and %3.</original>
 <translation>%1 は有効なエントリではありません。
-%2 と %3 の間の値を入力してください。</translation>
+%2 から %3 までの値を入力してください。</translation>
 </phrase>
 
 <phrase>
@@ -3319,12 +3318,12 @@ Please enter a numeric value.</original>
 
 <phrase>
 <original>Resize layer (on-canvas)</original>
-<translation>レイヤーのサイズ変更 (オンキャンバス)</translation>
+<translation>レイヤーのサイズ変更 (キャンバス上)</translation>
 </phrase>
 
 <phrase>
 <original>Rotate layer (on-canvas)</original>
-<translation>レイヤーの回転 (オンキャンバス)</translation>
+<translation>レイヤーの回転 (キャンバス上)</translation>
 </phrase>
 
 <phrase>
@@ -3396,7 +3395,7 @@ Please enter a numeric value.</original>
 
 <phrase>
 <original>Paint stroke</original>
-<translation>ストロークのびょぅ画</translation>
+<translation>ストロークの描画</translation>
 </phrase>
 
 <!-- Paintbrush.bas contains 2 phrases.  One was a duplicate of an existing phrase, so only 1 new phrases were written to file. -->
@@ -3410,7 +3409,7 @@ Please enter a numeric value.</original>
 
 <phrase>
 <original>(enter text here)</original>
-<translation>(ここにテキストを入力する)</translation>
+<translation>(ここにテキストを入力してください)</translation>
 </phrase>
 
 <phrase>
@@ -3482,14 +3481,14 @@ Please enter a numeric value.</original>
 
 <phrase>
 <original>picas</original>
-<translation>ピカ</translation>
+<translation>パイカ</translation>
 </phrase>
 
 <!-- Units.bas contains 26 phrases. 13 were duplicates of existing phrases, so only 13 new phrases were written to file. -->
 
 <phrase>
 <original>Update check postponed (a check has been performed recently)</original>
-<translation>更新チェックの延期 (チェックは最近行われました)</translation>
+<translation>更新チェックが延期されました (最近チェックが実行されました)</translation>
 </phrase>
 
 <phrase>
@@ -3498,8 +3497,8 @@ Please enter a numeric value.</original>
 </phrase>
 
 <phrase>
-<original>Initializing software updater (this feature can be disabled from the Tools -> Options menu)</original>
-<translation>ソフトウェアのアップデータを初期化 (この機能は [ツール] -> [オプション] メニューで無効にできます)</translation>
+<original>Initializing software updater (this feature can be disabled from the Tools -&gt; Options menu)</original>
+<translation>ソフトウェアのアップデータを初期化 (この機能は [ツール] -&gt; [オプション] メニューで無効にできます)</translation>
 </phrase>
 
 <phrase>
@@ -3526,27 +3525,27 @@ Please enter a numeric value.</original>
 
 <phrase>
 <original>Toggle between 1x and repeating previews</original>
-<translation>プレビューの等速と繰り返しを切り替え</translation>
+<translation>等倍と繰り返しプレビューを切り替え</translation>
 </phrase>
 
 <phrase>
 <original>Previously saved presets can be selected here.  You can save the current settings as a new preset by clicking the Save Preset button on the right.</original>
-<translation>以前に保存したプリセットはここで選択できます。 右のプリセット保存ボタンをクリックすると、現在の設定を新しいプリセットとして保存できます。</translation>
+<translation>以前に保存したプリセットをここで選択できます。  右側の「プリセットを保存」ボタンをクリックすると、現在の設定を新しいプリセットとして保存できます。</translation>
 </phrase>
 
 <phrase>
 <original>Randomly select new settings for this tool.  This is helpful for exploring how different settings affect the image.</original>
-<translation>このツールの新しい設定をランダムに選択します。 これは、異なる設定が画像にどのような影響を与えるかを調べるのに便利です。</translation>
+<translation>このツールの新しい設定をランダムに選択します。  これは、さまざまな設定が画像にどのような影響を与えるかを調べるのに役立ちます。</translation>
 </phrase>
 
 <phrase>
 <original>Redo (fast-forward to a later state)</original>
-<translation>やり直し (後の状態に早送りする)</translation>
+<translation>やり直し (後の状態に早送り)</translation>
 </phrase>
 
 <phrase>
 <original>Reset all settings to their default values.</original>
-<translation>すべての設定を既定値に戻す。</translation>
+<translation>すべての設定を規定値に戻します。</translation>
 </phrase>
 
 <phrase>
@@ -3566,7 +3565,7 @@ Please enter a numeric value.</original>
 
 <phrase>
 <original>Toolbox panels close automatically, but you can pin one to keep it open.  (Pinned panels still close when switching tools or opening new panels.)</original>
-<translation>ツールボックスのパネルは自動的に閉じますが、ピン留めして開いておくことができます。  (ピン留めしたパネルは、ツールを切り替えたり新しいパネルを開いたりしても閉じます)</translation>
+<translation>ツール ボックスのパネルは自動的に閉じますが、ピン留めして開いておくことができます。  (ピン留めしたパネルは、ツールを切り替えたり新しいパネルを開いたりしても閉じます)</translation>
 </phrase>
 
 <phrase>
@@ -3578,17 +3577,17 @@ Please enter a numeric value.</original>
 
 <phrase>
 <original>This image does not contain any GPS metadata.</original>
-<translation>この画像にはGPSメタデータは含まれていません。</translation>
+<translation>この画像には GPS メタデータが含まれていません。</translation>
 </phrase>
 
 <phrase>
 <original>No GPS data found</original>
-<translation>GPSデータが見つからない</translation>
+<translation>GPS データが見つかりませんでした</translation>
 </phrase>
 
 <phrase>
 <original>Attempting to connect to the Internet</original>
-<translation>インターネットへの接続を試みる</translation>
+<translation>インターネットに接続しようとしています</translation>
 </phrase>
 
 <phrase>
@@ -3598,22 +3597,22 @@ Please enter a numeric value.</original>
 
 <phrase>
 <original>Verifying URL (this may take a moment)</original>
-<translation>URL の確認 (少し時間がかかります)</translation>
+<translation>URL を確認しています (少し時間がかかります)</translation>
 </phrase>
 
 <phrase>
 <original>PhotoDemon could not reach the target URL (%1).  If the problem persists, try downloading the file manually using your Internet browser.</original>
-<translation>PhotoDemon は対象の URL (%1) に到達できませんでした。  問題が解決しない場合、インターネットブラウザを使用して手動でファイルをダウンロードしてください。</translation>
+<translation>PhotoDemon は対象の URL (%1) に到達できませんでした。  問題が解決しない場合、インターネット ブラウザを使用して手動でファイルをダウンロードしてください。</translation>
 </phrase>
 
 <phrase>
 <original>Downloading</original>
-<translation>ダウンロード</translation>
+<translation>ダウンロード中</translation>
 </phrase>
 
 <phrase>
 <original>PhotoDemon lost Internet access. Please double-check your connection.</original>
-<translation>PhotoDemon はインターネットアクセスを失いました。接続を再確認してください。</translation>
+<translation>PhotoDemon はインターネット アクセスを失いました。接続を再確認してください。</translation>
 </phrase>
 
 <phrase>
@@ -3635,26 +3634,26 @@ Please enter a numeric value.</original>
 <original>Unfortunately, %1 prevented PhotoDemon from directly downloading this file. (Direct downloads are sometimes mistaken as hotlinking by misconfigured servers.)
 
 You will need to manually download this file using your Internet browser.</original>
-<translation>残念ながら、%1 は PhotoDemon がこのファイルを直接ダウンロードすることを妨げました。(直接のダウンロードは、時々、誤った設定のサーバによりホット リンクと間違われます)
+<translation>残念ながら、%1 により PhotoDemon がこのファイルを直接ダウンロードできませんでした。 (直接ダウンロードは、サーバーの構成が間違っているため、ホットリンクと誤認されることがあります)
 
-インターネットブラウザを使用して、このファイルを手動でダウンロードする必要があります。</translation>
+インターネット ブラウザを使用して、このファイルを手動でダウンロードする必要があります。</translation>
 </phrase>
 
 <!-- Web.bas contains 17 phrases. 5 were duplicates of existing phrases, so only 12 new phrases were written to file. -->
 
 <phrase>
 <original>Fit width</original>
-<translation>幅にフィット</translation>
+<translation>幅に合わせる</translation>
 </phrase>
 
 <phrase>
 <original>Fit height</original>
-<translation>高さにフィット</translation>
+<translation>高さに合わせる</translation>
 </phrase>
 
 <phrase>
 <original>Fit image</original>
-<translation>画像にフィット</translation>
+<translation>画像に合わせる</translation>
 </phrase>
 
 <!-- Zoom.bas contains 6 phrases. 3 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
@@ -3670,7 +3669,7 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>The clipboard is empty or it does not contain a valid picture format.  Please copy a valid image onto the clipboard and try again.</original>
-<translation>クリップボードが空か、有効な画像形式が含まれていません。 有効な画像をクリップボードにコピーして、もう一度やり直してください。</translation>
+<translation>クリップボードが空であるか、有効な画像形式が含まれていません。  有効な画像をクリップボードにコピーして、再試行してください。</translation>
 </phrase>
 
 <phrase>
@@ -3719,19 +3718,19 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>Please select a folder</original>
-<translation>フォルダを選択してください</translation>
+<translation>フォルダーを選択してください</translation>
 </phrase>
 
 <!-- pdFSO.cls contains 2 phrases.  One was a duplicate of an existing phrase, so only 1 new phrases were written to file. -->
 
 <phrase>
 <original>Optimizing animation frame %1 of %2</original>
-<translation>%2 個中の %1 個目のアニメーション フレームを最適化しています</translation>
+<translation>アニメーション フレーム %1 / %2 を最適化しています</translation>
 </phrase>
 
 <phrase>
 <original>Saving animation frame %1 of %2</original>
-<translation>%2 個中の %1 個目のアニメーション フレームを保存しています</translation>
+<translation>アニメーション フレーム %1 / %2 を保存しています</translation>
 </phrase>
 
 <phrase>
@@ -3757,12 +3756,12 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>Building color lookup</original>
-<translation>ビルディング カラー ルックアップ</translation>
+<translation>カラー ルックアップを構築</translation>
 </phrase>
 
 <phrase>
 <original>All supported LUTs</original>
-<translation>サポートされるすべてのLUT</translation>
+<translation>サポートされるすべての LUT</translation>
 </phrase>
 
 <phrase>
@@ -3823,7 +3822,7 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>XMP (Creative Commons)</original>
-<translation>XMP (クリエイティブ コモンズ)</translation>
+<translation>XMP (クリエイティブ・コモンズ)</translation>
 </phrase>
 
 <phrase>
@@ -3883,7 +3882,7 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>XMP (Fast Picture Viewer)</original>
-<translation>XMP (高速画像ビューア)</translation>
+<translation>XMP (Fast Picture Viewer)</translation>
 </phrase>
 
 <phrase>
@@ -3903,12 +3902,12 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>XMP (IPTC Core)</original>
-<translation>XMP (Iptcコア)</translation>
+<translation>XMP (IPTC コア)</translation>
 </phrase>
 
 <phrase>
 <original>XMP (IPTC Extension)</original>
-<translation>XMP (Iptc拡張)</translation>
+<translation>XMP (IPTC 拡張)</translation>
 </phrase>
 
 <phrase>
@@ -3973,27 +3972,27 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>XMP (PRISM for images)</original>
-<translation>XMP (画像用PRISM)</translation>
+<translation>XMP (画像用 PRISM)</translation>
 </phrase>
 
 <phrase>
 <original>XMP (PRISM)</original>
-<translation>XMP (プリズム)</translation>
+<translation>XMP (PRISM)</translation>
 </phrase>
 
 <phrase>
 <original>XMP (PRISM Rights)</original>
-<translation>XMP (Prismライツ)</translation>
+<translation>XMP (PRISM 権利)</translation>
 </phrase>
 
 <phrase>
 <original>XMP (PRISM Recipe)</original>
-<translation>XMP (Prismレシピ)</translation>
+<translation>XMP (PRISM レシピ)</translation>
 </phrase>
 
 <phrase>
 <original>XMP (PRISM Usage Rights)</original>
-<translation>XMP (Prism利用権)</translation>
+<translation>XMP (PRISM 利用権)</translation>
 </phrase>
 
 <phrase>
@@ -4003,12 +4002,12 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>XMP (Adobe SWF)</original>
-<translation>XMP (Adobeswf)</translation>
+<translation>XMP (Adobe SWF)</translation>
 </phrase>
 
 <phrase>
 <original>XMP (EXIF-TIFF)</original>
-<translation>Xmp (exif-tiff)</translation>
+<translation>XMP (EXIF-TIFF)</translation>
 </phrase>
 
 <phrase>
@@ -4023,12 +4022,12 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>XMP (Basic Job)</original>
-<translation>XMP (ベーシック・ジョブ)</translation>
+<translation>XMP (基本ジョブ)</translation>
 </phrase>
 
 <phrase>
 <original>XMP (Dynamic Media)</original>
-<translation>XMP (ダイナミックメディア)</translation>
+<translation>XMP (ダイナミック メディア)</translation>
 </phrase>
 
 <phrase>
@@ -4038,12 +4037,12 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>XMP (Note)</original>
-<translation>XMP (注)</translation>
+<translation>XMP (ノート)</translation>
 </phrase>
 
 <phrase>
 <original>XMP (Picture Licensing)</original>
-<translation>XMP (ピクチャーライセンス)</translation>
+<translation>XMP (画像ライセンス)</translation>
 </phrase>
 
 <phrase>
@@ -4053,7 +4052,7 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>XMP (Paged Text)</original>
-<translation>XMP (ページングされたテキスト)</translation>
+<translation>XMP (ページ化されたテキスト)</translation>
 </phrase>
 
 <phrase>
@@ -4063,7 +4062,7 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>Removing metadata with potential privacy concerns</original>
-<translation>プライバシーに関わる可能性のあるメタデータの削除</translation>
+<translation>プライバシーに関する潜在的な懸念があるメタデータの削除</translation>
 </phrase>
 
 <phrase>
@@ -4075,7 +4074,7 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>Unfortunately, the number of images you selected exceeds what Windows allows for a single load operation.  Please try again with a smaller set of images.</original>
-<translation>残念ながら、選択された画像の数は、Windows が 1 回の読み込み操作で許容する数を超えています。  より少ない画像セットで再試行してください。</translation>
+<translation>残念ながら、選択した画像の数が Windows で許可されている1回の読み込み操作を超えています。  少ないセットの画像で再試行してください。 </translation>
 </phrase>
 
 <phrase>
@@ -4087,14 +4086,14 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>palette exported by PhotoDemon %1</original>
-<translation>PhotoDemon %1 によってエクスポートされたパレット。</translation>
+<translation>PhotoDemon %1 によってエクスポートされたパレット</translation>
 </phrase>
 
 <!-- pdPalette.cls contains 4 phrases. 3 were duplicates of existing phrases, so only one new phrase was written to file. -->
 
 <phrase>
 <original>Analyzing animation frame %1 of %2</original>
-<translation>%2 個中の %1 個目のアニメーション フレームを解析しています。</translation>
+<translation>アニメーション フレーム %1 / %2 を分析中</translation>
 </phrase>
 
 <!-- pdPNG.cls contains 5 phrases. 4 were duplicates of existing phrases, so only one new phrase was written to file. -->
@@ -4139,12 +4138,12 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>braid</original>
-<translation>ブレード</translation>
+<translation>編み</translation>
 </phrase>
 
 <phrase>
 <original>cross</original>
-<translation>クロス</translation>
+<translation>十字</translation>
 </phrase>
 
 <phrase>
@@ -4154,7 +4153,7 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>ragged</original>
-<translation>おぞい</translation>
+<translation>ボロボロ</translation>
 </phrase>
 
 <!-- pdVoronoi.cls contains 22 phrases. 17 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
@@ -4198,7 +4197,7 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>Mouse Wheel = VERTICAL SCROLL,  Shift + Wheel = HORIZONTAL SCROLL,  Ctrl + Wheel = ZOOM</original>
-<translation>マウス ホイール = 垂直スクロール、Shif + ホイール = 水平スクロール、Ctrl + ホイール = ズーム</translation>
+<translation>マウス ホイール = 垂直スクロール、  Shift + ホイール = 水平スクロール、  Ctrl + ホイール = ズーム</translation>
 </phrase>
 
 <phrase>
@@ -4267,12 +4266,12 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>original file settings</original>
-<translation>元のファイル設定</translation>
+<translation>元のファイルの設定</translation>
 </phrase>
 
 <phrase>
 <original>auto</original>
-<translation>オート</translation>
+<translation>自動</translation>
 </phrase>
 
 <phrase>
@@ -4319,7 +4318,7 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>RGB(%1, %2, %3)</original>
-<translation>RGBs(%1, %2, %3)</translation>
+<translation>RGB(%1, %2, %3)</translation>
 </phrase>
 
 <phrase>
@@ -4366,27 +4365,27 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>Increase red</original>
-<translation>赤を上げる</translation>
+<translation>赤を増やす</translation>
 </phrase>
 
 <phrase>
 <original>Increase green</original>
-<translation>緑を上げる</translation>
+<translation>緑を増やす</translation>
 </phrase>
 
 <phrase>
 <original>Increase blue</original>
-<translation>青を上げる</translation>
+<translation>青を増やす</translation>
 </phrase>
 
 <phrase>
 <original>Decrease luminance</original>
-<translation>明度を下げる</translation>
+<translation>輝度を下げる</translation>
 </phrase>
 
 <phrase>
 <original>Decrease saturation</original>
-<translation>明度を下げる</translation>
+<translation>彩度を下げる</translation>
 </phrase>
 
 <phrase>
@@ -4396,17 +4395,17 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>Decrease blue</original>
-<translation>青を下げる</translation>
+<translation>青を減らす</translation>
 </phrase>
 
 <phrase>
 <original>Decrease green</original>
-<translation>緑を下げる</translation>
+<translation>緑を減らす</translation>
 </phrase>
 
 <phrase>
 <original>Decrease red</original>
-<translation>赤を下げる</translation>
+<translation>赤を減らす</translation>
 </phrase>
 
 <!-- pdColorVariants.ctl contains 28 phrases. 15 were duplicates of existing phrases, so only 13 new phrases were written to file. -->
@@ -4435,7 +4434,7 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>Preset save canceled.</original>
-<translation>プリセット保存をキャンセルしました。</translation>
+<translation>プリセットの保存をキャンセルしました。</translation>
 </phrase>
 
 <phrase>
@@ -4445,7 +4444,7 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>This button will open a new issue page in your web browser.  You will need a GitHub account to proceed.</original>
-<translation>このボタンをクリックすると、ウェブブラウザに新しい issue ページが開きます。  次に進むには GitHub アカウントが必要です。</translation>
+<translation>このボタンをクリックすると、Web ブラウザで新しい問題ページが開きます。  続行するには GitHub アカウントが必要です。</translation>
 </phrase>
 
 <phrase>
@@ -4502,14 +4501,14 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>Rearrange layers</original>
-<translation>レイヤーの再配置</translation>
+<translation>レイヤーの並べ替え</translation>
 </phrase>
 
 <!-- pdLayerListInner.ctl contains 9 phrases. 8 were duplicates of existing phrases, so only one new phrase was written to file. -->
 
 <phrase>
 <original>general metadata settings</original>
-<translation>一般的なメタデータの設定</translation>
+<translation>一般的なメタデータ設定</translation>
 </phrase>
 
 <phrase>
@@ -4599,7 +4598,7 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>The final width and height measurements must be between 1 and 32760 pixels.</original>
-<translation>最終的な幅と高さの寸法は、1から32760ピクセルの間でなければなりません。</translation>
+<translation>最終的な幅と高さの測定値は 1 ～ 32760 ピクセルである必要があります。</translation>
 </phrase>
 
 <phrase>
@@ -4609,7 +4608,7 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>Preserve aspect ratio (sometimes called Constrain Proportions).  Use this option to resize an image while keeping the width and height in sync.</original>
-<translation>アスペクト比を保持 (Constrain Proportionsと呼ばれることもあります)。  このオプションを使うと、幅と高さを同期させたまま画像のサイズを変更できます。</translation>
+<translation>縦横比を維持します (コンストレイン ポジションとも呼ばれます)。幅と高さを同期させながら画像のサイズを変更するには、このオプションを使用します。</translation>
 </phrase>
 
 <phrase>
@@ -4624,7 +4623,7 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>Change the unit of measurement used for image resolution (pixel density).</original>
-<translation>画像解像度 (ピクセル密度)の単位を変更します。</translation>
+<translation>画像解像度 (ピクセル密度) の単位を変更します。</translation>
 </phrase>
 
 <phrase>
@@ -4649,14 +4648,14 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>%1, was %2</original>
-<translation>%1、%2 だった</translation>
+<translation>%1、 %2でした</translation>
 </phrase>
 
 <!-- pdResize.ctl contains 38 phrases. 24 were duplicates of existing phrases, so only 14 new phrases were written to file. -->
 
 <phrase>
 <original>Scroll here</original>
-<translation>ここをスクロール</translation>
+<translation>ここにスクロール</translation>
 </phrase>
 
 <phrase>
@@ -4701,12 +4700,12 @@ You will need to manually download this file using your Internet browser.</origi
 
 <phrase>
 <original>Scroll left</original>
-<translation>左スクロール</translation>
+<translation>左にスクロール</translation>
 </phrase>
 
 <phrase>
 <original>Scroll right</original>
-<translation>右スクロール</translation>
+<translation>右にスクロール</translation>
 </phrase>
 
 <phrase>
@@ -4729,13 +4728,13 @@ You will need to manually download this file using your Internet browser.</origi
 <phrase>
 <original>"%1" produces an out of range result (%2).
 The final value must be between %3 and %4.</original>
-<translation>"%1" は範囲外の結果 (%2) を生成します。
-最終値は %3 から %4 の間でなければならない。</translation>
+<translation>“%1” は範囲外の結果を生成します (%2)。
+最終値は %3 ～ %4 の範囲にする必要があります。</translation>
 </phrase>
 
 <phrase>
 <original>PhotoDemon doesn't understand the expression: %1</original>
-<translation>PhotoDemon は式を理解しません:  %1</translation>
+<translation>PhotoDemon は次の式を理解できません: %1</translation>
 </phrase>
 
 <!-- pdSpinner.ctl contains 20 phrases. 17 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
@@ -5089,7 +5088,7 @@ The final value must be between %3 and %4.</original>
 
 <phrase>
 <original>Fit to image</original>
-<translation>画像にフィット</translation>
+<translation>画像に合わせる</translation>
 </phrase>
 
 <phrase>
@@ -5624,7 +5623,7 @@ The final value must be between %3 and %4.</original>
 
 <phrase>
 <original>About</original>
-<translation>このアプリケーションについて</translation>
+<translation>PhotoDaemon について</translation>
 </phrase>
 
 <phrase>
@@ -5662,7 +5661,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Updates unavailable</original>
-<translation>アップデート不可</translation>
+<translation>アップデートは利用できません</translation>
 </phrase>
 
 <phrase>
@@ -5724,7 +5723,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>final colors</original>
-<translation>最終色</translation>
+<translation>最終的な色</translation>
 </phrase>
 
 <phrase>
@@ -5739,7 +5738,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Converting image to two colors</original>
-<translation>画像を2色に変換する</translation>
+<translation>画像を 2 色に変換する</translation>
 </phrase>
 
 <!-- Adjustments_BlackAndWhite.frm contains 11 phrases.  One was a duplicate of an existing phrase, so only 10 new phrases were written to file. -->
@@ -5751,7 +5750,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>sample image for true contrast (slower but more accurate)</original>
-<translation>真のコントラストのためのサンプル画像 (時間はかかるが、より正確)</translation>
+<translation>真のコントラストのサンプル画像 (遅いがより正確)</translation>
 </phrase>
 
 <phrase>
@@ -6015,19 +6014,19 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Your LUT collection is stored in the "%1" folder</original>
-<translation>LUT コレクションは "%1" フォルダに保存されます。</translation>
+<translation>LUT コレクションは "%1" フォルダーに保存されます。</translation>
 </phrase>
 
 <phrase>
 <original>click to open this folder in Windows Explorer</original>
-<translation>クリックすると、このフォルダがエクスプローラで開きます。</translation>
+<translation>クリックすると、このフォルダーをエクスプローラーで開きます</translation>
 </phrase>
 
 <!-- Adjustments_Color_Lookup.frm contains 14 phrases. 7 were duplicates of existing phrases, so only 7 new phrases were written to file. -->
 
 <phrase>
 <original>replace threshold</original>
-<translation>置き換えのしきい値</translation>
+<translation>しきい値を置き換え</translation>
 </phrase>
 
 <phrase>
@@ -6054,7 +6053,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Engaging hipsters to perform sepia conversion</original>
-<translation>ヒップスターにセピア変換を依頼</translation>
+<translation>おしゃれなセピア変換の実行</translation>
 </phrase>
 
 <!-- Adjustments_Color_Sepia.frm contains 4 phrases. 2 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
@@ -6219,12 +6218,12 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>fill histogram curves</original>
-<translation>塗りつぶしヒストグラム曲線</translation>
+<translation>ヒストグラム曲線を塗りつぶす</translation>
 </phrase>
 
 <phrase>
 <original>visible channels</original>
-<translation>可視チャンネル</translation>
+<translation>可視チャネル</translation>
 </phrase>
 
 <phrase>
@@ -6234,7 +6233,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>(Note: move the mouse over the histogram to calculate these values)</original>
-<translation>(注: これらの値を計算するには、ヒストグラムの上にマウスを移動してください)</translation>
+<translation>(注: これらの値を計算するには、ヒストグラム上にマウスを移動します)</translation>
 </phrase>
 
 <phrase>
@@ -6249,17 +6248,17 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>maximum count</original>
-<translation>最大カウント</translation>
+<translation>最大数</translation>
 </phrase>
 
 <phrase>
 <original>total pixels</original>
-<translation>総画素数</translation>
+<translation>総ピクセル数</translation>
 </phrase>
 
 <phrase>
 <original>max count</original>
-<translation>最大カウント</translation>
+<translation>最大数</translation>
 </phrase>
 
 <phrase>
@@ -6286,7 +6285,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>kernel shape</original>
-<translation>カーネルシェイプ</translation>
+<translation>カーネル シェイプ</translation>
 </phrase>
 
 <phrase>
@@ -6328,12 +6327,12 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>When this button is active, you can set the shadow input level color by right-clicking a color in the preview window.</original>
-<translation>このボタンがアクティブの場合、プレビューウィンドウで色を右クリックして、シャドウ入力レベルの色を設定できます。</translation>
+<translation>このボタンがアクティブな場合、プレビュー ウィンドウで色を右クリックしてシャドウ入力レベルの色を設定できます。</translation>
 </phrase>
 
 <phrase>
 <original>When this button is active, you can set the highlight input level color by right-clicking a color in the preview window.</original>
-<translation>このボタンがアクティブのときは、プレビュー ウィンドウで色を右クリックして、ハイライト入力レベルの色を設定できます。</translation>
+<translation>このボタンがアクティブな場合、プレビュー ウィンドウで色を右クリックして、ハイライト入力レベルの色を設定できます。</translation>
 </phrase>
 
 <phrase>
@@ -6355,7 +6354,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Removing haze from image</original>
-<translation>画像からかすみを取り除く</translation>
+<translation>画像からかすみを除去する</translation>
 </phrase>
 
 <!-- Adjustments_Lighting_Dehaze.frm contains 7 phrases. 4 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
@@ -6389,7 +6388,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>new gamma curve</original>
-<translation>新しいガンマ曲線</translation>
+<translation>新しいガンマ カーブ</translation>
 </phrase>
 
 <phrase>
@@ -6432,8 +6431,8 @@ The update is automatically processing in the background.  You will receive a ne
 </phrase>
 
 <phrase>
-<original>Like all monochrome-to-grayscale tools, this tool will produce a blurry image.  You can use the Effects -> Sharpen -> Unsharp Masking tool to fix this.  (For best results, use an Unsharp Mask radius at least as large as this radius.)</original>
-<translation>他のモノクロからグレースケールへのツールと同様、このツールは、ぼやけた画像を生成します。  これを修正するには、 [エフェクト] -> [シャープ] -> [アンシャープ マスク] ツールを使用します。  (最良の結果を得るには、少なくともこの半径と同じ大きさのアンシャープマスク半径を使用してください)</translation>
+<original>Like all monochrome-to-grayscale tools, this tool will produce a blurry image.  You can use the Effects -&gt; Sharpen -&gt; Unsharp Masking tool to fix this.  (For best results, use an Unsharp Mask radius at least as large as this radius.)</original>
+<translation>すべてのモノクロからグレースケールへのツールと同様に、このツールはぼやけた画像を生成します。  これを修正するには、[エフェクト] -&gt; [シャープ] -&gt; [アンシャープ マスク] ツールを使用します。 (最良の結果を得るには、少なくともこの半径と同じ大きさのアンシャープ マスク半径を使用してください。)</translation>
 </phrase>
 
 <!-- Adjustments_Monochrome_MonoToGray.frm contains 8 phrases. 4 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
@@ -6482,7 +6481,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Yellow</original>
-<translation>黄</translation>
+<translation>黄色</translation>
 </phrase>
 
 <phrase>
@@ -6497,7 +6496,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Blue</original>
-<translation>ブルー</translation>
+<translation>青</translation>
 </phrase>
 
 <phrase>
@@ -6512,22 +6511,22 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Deep red</original>
-<translation>ディープレッド</translation>
+<translation>深紅</translation>
 </phrase>
 
 <phrase>
 <original>Deep blue</original>
-<translation>ディープブルー</translation>
+<translation>藍色</translation>
 </phrase>
 
 <phrase>
 <original>Deep emerald</original>
-<translation>ディープ エメラルド</translation>
+<translation>深いエメラルド</translation>
 </phrase>
 
 <phrase>
 <original>Deep yellow</original>
-<translation>ディープイエロー</translation>
+<translation>濃い黄色</translation>
 </phrase>
 
 <phrase>
@@ -6620,12 +6619,12 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>A previous PhotoDemon session terminated unexpectedly.  Would you like to automatically recover the following autosaved images?</original>
-<translation>以前の PhotoDemon セッションが予期せず終了しました。  以下の自動保存された画像を回復しますか?</translation>
+<translation>以前の PhotoDemon セッションが予期せず終了しました。  以下の自動保存された画像を自動的に復元しますか?</translation>
 </phrase>
 
 <phrase>
 <original>If you exit now, this autosave data will be lost forever.  Are you sure you want to exit?</original>
-<translation>いま終了すると、この自動保存データは永遠に失われます。  本当に終了しますか?</translation>
+<translation>ここで終了すると、この自動保存データは永久に失われます。  本当に終了してもよろしいですか?</translation>
 </phrase>
 
 <phrase>
@@ -6681,7 +6680,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>delete preset</original>
-<translation>削除プリセット</translation>
+<translation>プリセットを削除</translation>
 </phrase>
 
 <phrase>
@@ -6721,7 +6720,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Preset name required</original>
-<translation>プリセット名必須</translation>
+<translation>プリセット名が必要です</translation>
 </phrase>
 
 <phrase>
@@ -6819,7 +6818,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Gradient editor</original>
-<translation>グラデーションの編集</translation>
+<translation>グラデーション エディター</translation>
 </phrase>
 
 <phrase>
@@ -6874,7 +6873,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>node editor</original>
-<translation>ノード エディタ</translation>
+<translation>ノード エディター</translation>
 </phrase>
 
 <phrase>
@@ -6923,8 +6922,8 @@ The update is automatically processing in the background.  You will receive a ne
 </phrase>
 
 <phrase>
-<original>edit this gradient >></original>
-<translation>このグラデーションを編集 >></translation>
+<original>edit this gradient &gt;&gt;</original>
+<translation>このグラデーションを編集 &gt;&gt;</translation>
 </phrase>
 
 <phrase>
@@ -6934,12 +6933,12 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>your collection</original>
-<translation>コレクション</translation>
+<translation>あなたのコレクション</translation>
 </phrase>
 
 <phrase>
 <original>A gradient with the name "%1" already exists in your collection.  Would you like to overwrite it?</original>
-<translation>名前 "%1" のグラデーションが既にコレクションに存在します。  上書きしますか?</translation>
+<translation>"%1" という名前のグラデーションがコレクション内にすでに存在します。  上書きしますか?</translation>
 </phrase>
 
 <phrase>
@@ -6954,12 +6953,12 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Name required</original>
-<translation>名前必須</translation>
+<translation>名前は必須です</translation>
 </phrase>
 
 <phrase>
 <original>All supported gradients</original>
-<translation>すべてのグラデーションに対応</translation>
+<translation>サポートされているすべてのグラデーション</translation>
 </phrase>
 
 <phrase>
@@ -6969,7 +6968,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>SVG Gradient</original>
-<translation>Svgグラデーション</translation>
+<translation>SVG グラデーション</translation>
 </phrase>
 
 <phrase>
@@ -6979,7 +6978,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Unfortunately, the gradient file "%1" doesn't appear to be a valid gradient file.</original>
-<translation>残念ながら、グラデーション ファイル"%1 "は有効なグラデーション ファイルではないようです。</translation>
+<translation>残念ながら、グラデーション ファイル "%1" は有効なグラデーション ファイルではないようです。</translation>
 </phrase>
 
 <phrase>
@@ -6999,7 +6998,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Left-click to add new nodes or edit existing nodes.  Right-click a node to remove it.</original>
-<translation>新しいノードを追加したり、既存のノードを編集するには、左クリックします。  ノードを削除するには、ノードを右クリックします。</translation>
+<translation>左クリックして新しいノードを追加するか、既存のノードを編集します。  ノードを右クリックして削除します。</translation>
 </phrase>
 
 <phrase>
@@ -7029,7 +7028,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Your gradient collection is stored in the "%1" folder</original>
-<translation>グラデーション コレクションは "%1" フォルダに保存されます。</translation>
+<translation>グラデーション コレクションは "%1" フォルダーに保存されます。</translation>
 </phrase>
 
 <phrase>
@@ -7071,12 +7070,12 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>I understand the risks of running PhotoDemon in the IDE</original>
-<translation>IDEでPhotoDemonを実行するリスクを理解しています。</translation>
+<translation>IDE で PhotoDemon を実行するリスクを理解しています</translation>
 </phrase>
 
 <phrase>
 <original>Do not display this warning again</original>
-<translation>この警告を再度表示しない</translation>
+<translation>この警告を今後表示しない</translation>
 </phrase>
 
 <!-- Dialog_IDEWarning.frm contains 2 phrases.  Both phrases were unique, so 2 new phrases were written to file. -->
@@ -7159,17 +7158,17 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>HDR image identified</original>
-<translation>HDR 画像の識別</translation>
+<translation>HDR 画像が識別されました</translation>
 </phrase>
 
 <phrase>
 <original>in the future, automatically apply these settings</original>
-<translation>将来、これらの設定を自動的に適用する</translation>
+<translation>今後、これらの設定を自動的に適用</translation>
 </phrase>
 
 <phrase>
 <original>tone-mapping operator</original>
-<translation>トーンマッピング演算子</translation>
+<translation>トーン マッピング演算子</translation>
 </phrase>
 
 <phrase>
@@ -7179,7 +7178,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>white point</original>
-<translation>ホワイトポイント</translation>
+<translation>ホワイト ポイント</translation>
 </phrase>
 
 <phrase>
@@ -7199,12 +7198,12 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>This image contains more than 16 million colors.  Before it can be displayed on your screen, it must be converted to a simpler format.  This process is called tone mapping.</original>
-<translation>この画像には1600万色以上の色が含まれています。  画面に表示する前に、よりシンプルなフォーマットに変換する必要があります。  この処理をトーンマッピングと呼びます。</translation>
+<translation>この画像には 1,600 万色以上の色が含まれています。  画面に表示するには、より単純な形式に変換する必要があります。  このプロセスはトーン マッピングと呼ばれます。</translation>
 </phrase>
 
 <phrase>
 <original>Waiting for tone mapping instructions</original>
-<translation>トーンマッピングの指示待ち</translation>
+<translation>トーンマッピングの指示を待っています</translation>
 </phrase>
 
 <phrase>
@@ -7219,7 +7218,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Filmic</original>
-<translation>フィルミック</translation>
+<translation>映画的な</translation>
 </phrase>
 
 <phrase>
@@ -7306,17 +7305,17 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Translation by %1</original>
-<translation>%1 が翻訳</translation>
+<translation>%1 による翻訳</translation>
 </phrase>
 
 <phrase>
 <original>You can change language and theme settings at any time from the Tools menu.</original>
-<translation>言語とテーマの設定は、ツール メニューからいつでも変更できます。</translation>
+<translation>言語とテーマの設定は、[ツール] メニューからいつでも変更できます。</translation>
 </phrase>
 
 <phrase>
 <original>Additional interface customizations are available in the Window menu.</original>
-<translation>その他のインターフェイスのカスタマイズはウインドウ メニューで可能です。</translation>
+<translation>追加のインターフェイスのカスタマイズは、[ウィンドウ] メニューで利用できます。</translation>
 </phrase>
 
 <!-- Dialog_UITheme.frm contains 23 phrases. 6 were duplicates of existing phrases, so only 17 new phrases were written to file. -->
@@ -7328,7 +7327,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>images with unsaved changes</original>
-<translation>未保存の変更のある画像</translation>
+<translation>変更が保存されていない画像</translation>
 </phrase>
 
 <phrase>
@@ -7338,7 +7337,7 @@ The update is automatically processing in the background.  You will receive a ne
 
 <phrase>
 <original>Repeat this action for all unsaved images (%1 in total)</original>
-<translation>保存されていないすべての画像 (合計 %1)に対してこの操作を繰り返します。</translation>
+<translation>すべての未保存の画像 (合計 %1) に対してこの操作を繰り返す</translation>
 </phrase>
 
 <phrase>
@@ -7354,15 +7353,15 @@ The update is automatically processing in the background.  You will receive a ne
 <phrase>
 <original>NOTE: if you click 'Save', PhotoDemon will save this image using its current file name.
 
-If you want to save it with a different file name, please select 'Cancel', then use the File -> Save As menu item.</original>
-<translation>注意: 「保存」をクリックすると、PhotoDemon はこの画像を現在のファイル名で保存します。
+If you want to save it with a different file name, please select 'Cancel', then use the File -&gt; Save As menu item.</original>
+<translation>注: [保存] をクリックすると、PhotoDemon は現在のファイル名を使用してこの画像を保存します。
 
-異なるファイル名で保存したい場合、「キャンセル」を選択し、ファイル -> 名前を付けて保存メニュー項目を使用してください。</translation>
+別のファイル名で保存したい場合は、「キャンセル」を選択し、メニュー項目 [ファイル] -&gt; [名前を付けて保存] を使用してください。</translation>
 </phrase>
 
 <phrase>
 <original>Because this image has not been saved before, you will be prompted to provide a file name for it.</original>
-<translation>この画像は以前に保存されていないため、ファイル名を入力するよう求められます。</translation>
+<translation>この画像はこれまでに保存されていないため、ファイル名を指定するように求められます。</translation>
 </phrase>
 
 <phrase>
@@ -7372,7 +7371,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Canceling will return you to the main PhotoDemon window.</original>
-<translation>キャンセルすると、PhotoDemon のメインウィンドウに戻ります。</translation>
+<translation>キャンセルすると、PhotoDemon のメイン ウィンドウに戻ります。</translation>
 </phrase>
 
 <phrase>
@@ -7392,7 +7391,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Repeat this action for both unsaved images</original>
-<translation>保存されていないすべての画像にこの操作を繰り返す</translation>
+<translation>すべての未保存の画像に対してこの操作を繰り返す</translation>
 </phrase>
 
 <!-- Dialog_UnsavedChanges.frm contains 20 phrases. 6 were duplicates of existing phrases, so only 14 new phrases were written to file. -->
@@ -7414,12 +7413,12 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Keep working</original>
-<translation>働き続ける</translation>
+<translation>作業を続ける</translation>
 </phrase>
 
 <phrase>
 <original>Learn more about the new features in %1</original>
-<translation>%1 の新機能の詳細をご覧ください。</translation>
+<translation>%1 の新機能の詳細については、こちらをご覧ください。</translation>
 </phrase>
 
 <phrase>
@@ -7439,7 +7438,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Apply update now</original>
-<translation>今すぐアップデートを申し込む</translation>
+<translation>今すぐアップデートを適用する</translation>
 </phrase>
 
 <phrase>
@@ -7508,7 +7507,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>patch perfection threshold</original>
-<translation>パッチ パーフェクション しきい値</translation>
+<translation>パッチ完璧度のしきい値</translation>
 </phrase>
 
 <phrase>
@@ -7545,7 +7544,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Fading previous action (%1)</original>
-<translation>前のアクションのフェード (%1)</translation>
+<translation>前のアクションをフェードアウトしています (%1)</translation>
 </phrase>
 
 <phrase>
@@ -7582,7 +7581,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>use combined size (union)</original>
-<translation>複合サイズを使用 (ユニオン)</translation>
+<translation>結合サイズ (ユニオン) を使用</translation>
 </phrase>
 
 <!-- Edit_Fill.frm contains 11 phrases. 5 were duplicates of existing phrases, so only 6 new phrases were written to file. -->
@@ -7611,12 +7610,12 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>available image states</original>
-<translation>使用可能な画像状態</translation>
+<translation>利用可能な画像の状態</translation>
 </phrase>
 
 <phrase>
 <original>layer: %1</original>
-<translation>レイヤ: %1</translation>
+<translation>レイヤー: %1</translation>
 </phrase>
 
 <phrase>
@@ -7628,7 +7627,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>scan for new plugins</original>
-<translation>新しいプラグインを探す</translation>
+<translation>新しいプラグインをスキャンする</translation>
 </phrase>
 
 <phrase>
@@ -7643,27 +7642,27 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>add folder</original>
-<translation>フォルダを追加</translation>
+<translation>フォルダーを追加</translation>
 </phrase>
 
 <phrase>
 <original>default plugin folder</original>
-<translation>既定のプラグイン フォルダ</translation>
+<translation>規定のプラグインフォルダー</translation>
 </phrase>
 
 <phrase>
 <original>additional folders</original>
-<translation>追加のフォルダ</translation>
+<translation>追加のフォルダー</translation>
 </phrase>
 
 <phrase>
 <original>remove folder</original>
-<translation>フォルダを除去</translation>
+<translation>フォルダーを除去</translation>
 </phrase>
 
 <phrase>
 <original>Waiting for plugin</original>
-<translation>プラグイン待ち</translation>
+<translation>プラグインを待っています</translation>
 </phrase>
 
 <phrase>
@@ -7693,17 +7692,17 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Photoshop (8bf) plugins are files with an "8bf" extension.  These plugins provide new image effects.  Thousands of 8bf plugins are available online.</original>
-<translation>Photoshop (8Bf) プラグインは、拡張子が "8bf" のファイルです。  これらのプラグインは、新規画像効果を提供します。  何千もの 8bf プラグインがオンラインにあります。</translation>
+<translation>Photoshop (8bf) プラグインは、拡張子が「8bf」のファイルです。  これらのプラグインは、新しい画像効果を提供します。何千もの 8bf プラグインがオンラインで入手できます。</translation>
 </phrase>
 
 <phrase>
 <original>PhotoDemon does not ship with 8bf plugins, but if you find plugins online, you can download them and add them to PhotoDemon.  (PhotoDemon supports most 32-bit 8bf plugins.  64-bit plugins are not supported.)</original>
-<translation>PhotoDemon は 8bf プラグインを同梱しませんが、オンラインでプラグインを見つけた場合、それらをダウンロードして PhotoDemon に追加できます。  (PhotoDemon は、ほとんどの 32 ビット 8bf プラグインをサポートしています。  64 ビット プラグインはサポートされていません)</translation>
+<translation>PhotoDemon には 8bf プラグインが同梱されていませんが、オンラインでプラグインを見つけた場合は、ダウンロードして PhotoDemon に追加できます。 (PhotoDemon は、ほとんどの 32 ビット 8bf プラグインをサポートしています。  64 ビット プラグインはサポートされていません。)</translation>
 </phrase>
 
 <phrase>
 <original>After downloading one or more 8bf files, use the settings button (above) to tell PhotoDemon where to find them.  PhotoDemon will then add them to your Effects collection.</original>
-<translation>1 つまたは複数の 8bf ファイルをダウンロードしたあと、設定ボタン (上記) を使用して、PhotoDemon にそれらの場所を指定します。  PhotoDemon はそれらをエフェクト コレクションに追加します。</translation>
+<translation>1 つ以上の 8bf ファイルをダウンロードした後、設定ボタン (上) を使用して、PhotoDemon にファイルの場所を指示します。  PhotoDemon はそれらをエフェクト コレクションに追加します。</translation>
 </phrase>
 
 <!-- Effects_8bf.frm contains 25 phrases. 9 were duplicates of existing phrases, so only 16 new phrases were written to file. -->
@@ -7897,24 +7896,24 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Generating glass tiles</original>
-<translation>ガラスタイルの製造</translation>
+<translation>ガラスタイルの生成</translation>
 </phrase>
 
 <!-- Effects_Artistic_GlassTiles.frm contains 9 phrases. 7 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
 
 <phrase>
 <original>number of mirrors</original>
-<translation>ミラー数</translation>
+<translation>ミラーの数</translation>
 </phrase>
 
 <phrase>
 <original>primary angle</original>
-<translation>プライマリー角度</translation>
+<translation>主角</translation>
 </phrase>
 
 <phrase>
 <original>you can also set a center position by clicking the preview window</original>
-<translation>プレビュー ウィンドウをクリックして中心位置を設定することもできます。</translation>
+<translation>プレビュー ウィンドウをクリックして中心位置を設定することもできます</translation>
 </phrase>
 
 <phrase>
@@ -7924,17 +7923,17 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>secondary angle</original>
-<translation>副角度</translation>
+<translation>二次角度</translation>
 </phrase>
 
 <phrase>
 <original>radius (percentage)</original>
-<translation>半径</translation>
+<translation>半径 (パーセント)</translation>
 </phrase>
 
 <phrase>
 <original>render emphasis</original>
-<translation>強調レンダー</translation>
+<translation>強調表示</translation>
 </phrase>
 
 <phrase>
@@ -7956,7 +7955,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>vertical strength</original>
-<translation>垂直力</translation>
+<translation>垂直強度</translation>
 </phrase>
 
 <phrase>
@@ -7995,12 +7994,12 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>light intensity</original>
-<translation>光度</translation>
+<translation>光強度</translation>
 </phrase>
 
 <phrase>
 <original>Wrapping image in plastic</original>
-<translation>画像をビニールで包む</translation>
+<translation>画像をプラスチックのビニールで包む</translation>
 </phrase>
 
 <!-- Effects_Artistic_PlasticWrap.frm contains 8 phrases. 3 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
@@ -8027,14 +8026,14 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Posterizing image</original>
-<translation>ポスター画像</translation>
+<translation>画像をポスタライズする</translation>
 </phrase>
 
 <!-- Effects_Artistic_Posterize.frm contains 11 phrases. 6 were duplicates of existing phrases, so only 5 new phrases were written to file. -->
 
 <phrase>
 <original>Carving image relief</original>
-<translation>彫像レリーフ</translation>
+<translation>画像のレリーフ彫刻</translation>
 </phrase>
 
 <!-- Effects_Artistic_Relief.frm contains 6 phrases. 5 were duplicates of existing phrases, so only one new phrase was written to file. -->
@@ -8096,14 +8095,14 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Chebyshev (chessboard)</original>
-<translation>チェビシェフ</translation>
+<translation>チェビシェフ (チェス盤)</translation>
 </phrase>
 
 <!-- Effects_Artistic_StainedGlass.frm contains 22 phrases. 10 were duplicates of existing phrases, so only 12 new phrases were written to file. -->
 
 <phrase>
 <original>box width</original>
-<translation>ボックス幅</translation>
+<translation>ボックスの幅</translation>
 </phrase>
 
 <phrase>
@@ -8140,7 +8139,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>radius (Photoshop equivalent)</original>
-<translation>半径 (Photoshopと同等)</translation>
+<translation>半径 (Photoshop と同等)</translation>
 </phrase>
 
 <phrase>
@@ -8189,7 +8188,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>gaussian</original>
-<translation>ガウシアン</translation>
+<translation>ガウス</translation>
 </phrase>
 
 <!-- Effects_Blur_MotionBlur.frm contains 9 phrases. 5 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
@@ -8283,7 +8282,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>correction strength</original>
-<translation>修正強度</translation>
+<translation>補正強度</translation>
 </phrase>
 
 <phrase>
@@ -8344,22 +8343,22 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Miscellaneous distorts</original>
-<translation>雑多な歪み</translation>
+<translation>その他のゆがみ</translation>
 </phrase>
 
 <phrase>
 <original>distortions</original>
-<translation>歪曲</translation>
+<translation>ゆがみ</translation>
 </phrase>
 
 <phrase>
 <original>Applying %1 distortion</original>
-<translation>歪み %1 の適用</translation>
+<translation>ゆがみ %1 を適用しています</translation>
 </phrase>
 
 <phrase>
 <original>emphasize center</original>
-<translation>センター重視</translation>
+<translation>中央を強調</translation>
 </phrase>
 
 <phrase>
@@ -8384,7 +8383,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>twist edges</original>
-<translation>ツイスト エッジ</translation>
+<translation>エッジをねじる</translation>
 </phrase>
 
 <phrase>
@@ -8413,7 +8412,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Poking image</original>
-<translation>画像を突き刺す</translation>
+<translation>画像をつつく</translation>
 </phrase>
 
 <!-- Effects_Distort_Poke.frm contains 8 phrases. 7 were duplicates of existing phrases, so only one new phrase was written to file. -->
@@ -8430,7 +8429,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>time (phase)</original>
-<translation>じそう</translation>
+<translation>時間 (位相)</translation>
 </phrase>
 
 <phrase>
@@ -8442,7 +8441,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Squeezing image</original>
-<translation>スクイーズ画像</translation>
+<translation>画像をしぼる</translation>
 </phrase>
 
 <!-- Effects_Distort_Squish.frm contains 7 phrases. 6 were duplicates of existing phrases, so only one new phrase was written to file. -->
@@ -8466,12 +8465,12 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>horizontal strength (amplitude)</original>
-<translation>水平強度</translation>
+<translation>水平方向の強度 (振幅)</translation>
 </phrase>
 
 <phrase>
 <original>vertical strength (amplitude)</original>
-<translation>垂直力 (振幅)</translation>
+<translation>垂直方向の強度 (振幅)</translation>
 </phrase>
 
 <phrase>
@@ -8515,27 +8514,27 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Applying pass %1 of %2 for %3 filter</original>
-<translation>%2 個中 %1 個目のパスを %3 フィルターに適用しています。</translation>
+<translation>%3 フィルタにパス %1 / %2 を適用しています</translation>
 </phrase>
 
 <phrase>
 <original>Artistic contour edge detection</original>
-<translation>芸術的輪郭エッジ検出</translation>
+<translation>芸術的な輪郭エッジ検出</translation>
 </phrase>
 
 <phrase>
 <original>Hilite edge detection</original>
-<translation>ヒライトエッジ検出</translation>
+<translation>ハイライト エッジ検出</translation>
 </phrase>
 
 <phrase>
 <original>Laplacian edge detection</original>
-<translation>ラプラシアンエッジ検出</translation>
+<translation>ラプラシアン エッジ検出</translation>
 </phrase>
 
 <phrase>
 <original>PhotoDemon edge detection</original>
-<translation>PhotoDemonエッジ検出</translation>
+<translation>PhotoDemon エッジ検出</translation>
 </phrase>
 
 <phrase>
@@ -8545,7 +8544,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Roberts cross edge detection</original>
-<translation>ロバーツのクロスエッジ検出</translation>
+<translation>ロバーツ クロス エッジ検出</translation>
 </phrase>
 
 <phrase>
@@ -8555,7 +8554,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Artistic contour</original>
-<translation>芸術的輪郭</translation>
+<translation>芸術的な輪郭</translation>
 </phrase>
 
 <phrase>
@@ -8599,7 +8598,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>boost</original>
-<translation>高める</translation>
+<translation>ブースト</translation>
 </phrase>
 
 <phrase>
@@ -8624,7 +8623,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>dynamic</original>
-<translation>ダイナミック</translation>
+<translation>動的</translation>
 </phrase>
 
 <phrase>
@@ -8694,7 +8693,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>softness</original>
-<translation>やわらかさ</translation>
+<translation>柔らかさ</translation>
 </phrase>
 
 <phrase>
@@ -8723,7 +8722,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>number of rays</original>
-<translation>光線数</translation>
+<translation>光線の数</translation>
 </phrase>
 
 <phrase>
@@ -8759,7 +8758,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>color intensity</original>
-<translation>色強度</translation>
+<translation>色の濃さ</translation>
 </phrase>
 
 <phrase>
@@ -8795,14 +8794,14 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Let it snow, let it snow, let it snow</original>
-<translation>雪を降らせろ、雪を降らせろ、雪を降らせろ</translation>
+<translation>雪よ降れ、雪よ降れ、雪よ降れ </translation>
 </phrase>
 
 <!-- Effects_Nature_Snow.frm contains 9 phrases. 7 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
 
 <phrase>
 <original>color shift</original>
-<translation>色ずれ</translation>
+<translation>カラー シフト</translation>
 </phrase>
 
 <phrase>
@@ -8814,12 +8813,12 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>appearance</original>
-<translation>表示</translation>
+<translation>外観</translation>
 </phrase>
 
 <phrase>
 <original>distribution</original>
-<translation>流通</translation>
+<translation>分布</translation>
 </phrase>
 
 <phrase>
@@ -8829,14 +8828,14 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>uniform</original>
-<translation>ユニフォーム</translation>
+<translation>均一</translation>
 </phrase>
 
 <!-- Effects_Noise_AddRGBNoise.frm contains 10 phrases. 6 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
 
 <phrase>
 <original>directionality</original>
-<translation>指向性</translation>
+<translation>方向性</translation>
 </phrase>
 
 <phrase>
@@ -8846,7 +8845,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Calculating energy gradients (pass %1 of %2)</original>
-<translation>エネルギー勾配の計算 (%2 個中 %1 個目のパス)</translation>
+<translation>エネルギー勾配を計算中 (パス %1 / %2)</translation>
 </phrase>
 
 <phrase>
@@ -8866,7 +8865,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>sharpen</original>
-<translation>明確化</translation>
+<translation>シャープ</translation>
 </phrase>
 
 <phrase>
@@ -8883,7 +8882,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Fixing dust and scratches</original>
-<translation>ほこりや傷の修復</translation>
+<translation>ほこりと傷の修復</translation>
 </phrase>
 
 <!-- Effects_Noise_DustAndScratches.frm contains 6 phrases. 4 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
@@ -8895,14 +8894,14 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Softening film grain</original>
-<translation>フィルム グレインを和らげる</translation>
+<translation>フィルム グレインのソフト化</translation>
 </phrase>
 
 <!-- Effects_Noise_FilmGrain.frm contains 6 phrases. 4 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
 
 <phrase>
 <original>Applying harmonic mean filter</original>
-<translation>高調波平均フィルターの適用</translation>
+<translation>調和平均フィルターの適用</translation>
 </phrase>
 
 <!-- Effects_Noise_HarmonicMean.frm contains 7 phrases. 6 were duplicates of existing phrases, so only one new phrase was written to file. -->
@@ -8931,29 +8930,29 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Applying median filter</original>
-<translation>中心値フィルターの適用</translation>
+<translation>メディアン フィルターの適用</translation>
 </phrase>
 
 <!-- Effects_Noise_MedianSmoothing.frm contains 15 phrases. 11 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
 
 <phrase>
 <original>cyan angle</original>
-<translation>シアン角</translation>
+<translation>シアン角度</translation>
 </phrase>
 
 <phrase>
 <original>magenta angle</original>
-<translation>マゼンタ角</translation>
+<translation>マゼンタ角度</translation>
 </phrase>
 
 <phrase>
 <original>yellow angle</original>
-<translation>イエロー角</translation>
+<translation>イエロー角度</translation>
 </phrase>
 
 <phrase>
 <original>Printing image to digital halftone surface</original>
-<translation>デジタル ハーフトーン面で画像を印刷しています</translation>
+<translation>画像をデジタル ハーフトーン サーフェスに印刷しています</translation>
 </phrase>
 
 <!-- Effects_Pixelate_ColorHalftone.frm contains 8 phrases. 4 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
@@ -8967,12 +8966,12 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>number of fragments</original>
-<translation>断片数</translation>
+<translation>フラグメントの数</translation>
 </phrase>
 
 <phrase>
 <original>Calculating image fragments</original>
-<translation>画像断片の計算</translation>
+<translation>画像フラグメントの計算</translation>
 </phrase>
 
 <phrase>
@@ -8989,7 +8988,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>randomness</original>
-<translation>偶然性</translation>
+<translation>ランダム性</translation>
 </phrase>
 
 <phrase>
@@ -8999,17 +8998,17 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Mezzotinting image</original>
-<translation>画像のメゾチント</translation>
+<translation>画像のメゾチント処理</translation>
 </phrase>
 
 <phrase>
 <original>dot</original>
-<translation>点</translation>
+<translation>ドット</translation>
 </phrase>
 
 <phrase>
 <original>horizontal stroke</original>
-<translation>横ストローク</translation>
+<translation>水平ストローク</translation>
 </phrase>
 
 <phrase>
@@ -9031,7 +9030,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>synchronize block size</original>
-<translation>ブロックサイズを同期させる</translation>
+<translation>ブロックサイズを同期</translation>
 </phrase>
 
 <phrase>
@@ -9053,7 +9052,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Splattering canvas with paint</original>
-<translation>キャンバスに絵の具をぶちまける</translation>
+<translation>キャンバスにペンキを飛ばす</translation>
 </phrase>
 
 <!-- Effects_Pixelate_Pointillize.frm contains 8 phrases. 7 were duplicates of existing phrases, so only one new phrase was written to file. -->
@@ -9065,7 +9064,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Rendering clouds</original>
-<translation>雲のレンダリング</translation>
+<translation>雲の描画</translation>
 </phrase>
 
 <phrase>
@@ -9082,12 +9081,12 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>grain</original>
-<translation>穀物</translation>
+<translation>粒</translation>
 </phrase>
 
 <phrase>
 <original>Rendering fibers</original>
-<translation>レンダリングファイバー</translation>
+<translation>繊維の描画</translation>
 </phrase>
 
 <!-- Effects_Render_Fibers.frm contains 16 phrases. 13 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
@@ -9120,7 +9119,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>color fade</original>
-<translation>色フェード</translation>
+<translation>色あせ</translation>
 </phrase>
 
 <phrase>
@@ -9130,31 +9129,31 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>fade edges</original>
-<translation>フェード エッジ</translation>
+<translation>エッジのフェード</translation>
 </phrase>
 
 <phrase>
 <original>Sending image back in time</original>
-<translation>画像を過去に送る</translation>
+<translation>画像を過去に戻す</translation>
 </phrase>
 
 <!-- Effects_Stylize_Antique.frm contains 7 phrases. 3 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
 
 <phrase>
 <original>wrap edge values</original>
-<translation>エッジのラップ値</translation>
+<translation>エッジ値をラップ</translation>
 </phrase>
 
 <phrase>
 <original>Simulating large image explosion</original>
-<translation>大きな画像の爆発をシミュレート</translation>
+<translation>大規模な画像爆発のシミュレーション</translation>
 </phrase>
 
 <!-- Effects_Stylize_Diffuse.frm contains 6 phrases. 4 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
 
 <phrase>
 <original>edge type</original>
-<translation>エッジタイプ</translation>
+<translation>エッジ タイプ</translation>
 </phrase>
 
 <phrase>
@@ -9166,17 +9165,17 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>use Lab color space</original>
-<translation>Lab カラースペースを使用</translation>
+<translation>Lab 色空間を使用する</translation>
 </phrase>
 
 <phrase>
 <original>quantization method</original>
-<translation>量子化法</translation>
+<translation>量子化方式</translation>
 </phrase>
 
 <phrase>
 <original>preserve white and black</original>
-<translation>白と黒を保つ</translation>
+<translation>白と黒を保持</translation>
 </phrase>
 
 <phrase>
@@ -9236,7 +9235,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Applying new palette to image</original>
-<translation>画像に新しいパレットを適用</translation>
+<translation>新しいパレットを画像に適用</translation>
 </phrase>
 
 <phrase>
@@ -9258,7 +9257,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>exposure boost</original>
-<translation>露出度アップ</translation>
+<translation>露出ブースト</translation>
 </phrase>
 
 <phrase>
@@ -9287,19 +9286,19 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>orientation</original>
-<translation>方向</translation>
+<translation>向き</translation>
 </phrase>
 
 <phrase>
 <original>Generating image twin</original>
-<translation>ツイン画像の生成</translation>
+<translation>軸対称画像の生成</translation>
 </phrase>
 
 <!-- Effects_Stylize_Twins.frm contains 6 phrases. 4 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
 
 <phrase>
 <original>Applying vignetting</original>
-<translation>ヴィネットの適用</translation>
+<translation>レンズのケラレの適用</translation>
 </phrase>
 
 <phrase>
@@ -9309,7 +9308,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>circular</original>
-<translation>サーキュラー</translation>
+<translation>円形</translation>
 </phrase>
 
 <!-- Effects_Stylize_Vignette.frm contains 15 phrases. 12 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
@@ -9331,7 +9330,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Applying pan and zoom (Ken Burns) effect</original>
-<translation>パン &amp; ズーム (ケン・バーンズ) 効果の適用</translation>
+<translation>パンとズーム (ケン・バーンズ) 効果の適用</translation>
 </phrase>
 
 <!-- Effects_Transform_PanZoom.frm contains 8 phrases. 4 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
@@ -9353,12 +9352,12 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>forward (outline defines destination area)</original>
-<translation>前進 (アウトラインは目的地を定義する)</translation>
+<translation>順方向 (アウトラインが宛先を定義)</translation>
 </phrase>
 
 <phrase>
 <original>reverse (outline defines source area)</original>
-<translation>リバース (アウトラインはソースエリアを定義する)</translation>
+<translation>逆方向 (アウトラインが元の領域を定義)</translation>
 </phrase>
 
 <phrase>
@@ -9390,7 +9389,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>conversion</original>
-<translation>コンバージョン</translation>
+<translation>変換</translation>
 </phrase>
 
 <phrase>
@@ -9405,7 +9404,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>Polar to rectangular</original>
-<translation>ポーラーからレクタンギュラーへ</translation>
+<translation>極座標から長方形へ</translation>
 </phrase>
 
 <phrase>
@@ -9421,8 +9420,8 @@ If you want to save it with a different file name, please select 'Cancel', then 
 </phrase>
 
 <phrase>
-<original>If you want to enlarge the canvas to fit the rotated image, please use the Image -> Rotate menu instead.</original>
-<translation>回転した画像に合わせてキャンバスを拡大したい場合は、代わりに [画像] -> [回転] メニューを使用してください。</translation>
+<original>If you want to enlarge the canvas to fit the rotated image, please use the Image -&gt; Rotate menu instead.</original>
+<translation>回転した画像に合わせてキャンバスを拡大したい場合は、代わりに [画像] -&gt; [回転] メニューを使用してください。</translation>
 </phrase>
 
 <!-- Effects_Transform_Rotate.frm contains 12 phrases. 10 were duplicates of existing phrases, so only 2 new phrases were written to file. -->
@@ -9434,19 +9433,19 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>vertical angle</original>
-<translation>ちょうかく</translation>
+<translation>垂直角</translation>
 </phrase>
 
 <phrase>
 <original>Shearing image</original>
-<translation>シャーリング画像</translation>
+<translation>画像のシアリング</translation>
 </phrase>
 
 <!-- Effects_Transform_Shear.frm contains 7 phrases. 4 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
 
 <phrase>
 <original>area outside sphere</original>
-<translation>球外領域</translation>
+<translation>球の外側の領域</translation>
 </phrase>
 
 <phrase>
@@ -9468,7 +9467,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>include subfolders</original>
-<translation>サブ フォルダを含む</translation>
+<translation>サブ フォルダーを含む</translation>
 </phrase>
 
 <phrase>
@@ -9483,12 +9482,12 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>source folder</original>
-<translation>ソースフォルダ</translation>
+<translation>ソースフォルダー</translation>
 </phrase>
 
 <phrase>
 <original>destination folder (for repaired files only)</original>
-<translation>保存先フォルダ (修復済みファイルのみ)</translation>
+<translation>保存先フォルダー (修復済みファイルのみ)</translation>
 </phrase>
 
 <phrase>
@@ -9508,7 +9507,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 
 <phrase>
 <original>overwrite matching filenames in the destination folder</original>
-<translation>コピー先フォルダ内の一致するファイル名を上書き</translation>
+<translation>コピー先フォルダー内の一致するファイル名を上書き</translation>
 </phrase>
 
 <phrase>
@@ -9537,7 +9536,7 @@ If you want to save it with a different file name, please select 'Cancel', then 
 Repaired files have been saved to the destination folder.  Unrepaired files remain in their original locations.</original>
 <translation>%1 個のファイルが修復されました。
 
-修復されたファイルが宛先フォルダに保存されました。  修復されなかったファイルは元の場所に残ります。</translation>
+修復されたファイルが宛先フォルダーに保存されました。  修復されなかったファイルは元の場所に残ります。</translation>
 </phrase>
 
 <phrase>
@@ -9547,7 +9546,7 @@ Repaired files have been saved to the destination folder.  Unrepaired files rema
 
 <phrase>
 <original>The source folder does not contain any files.  Please try another folder.</original>
-<translation>ソースフォルダにファイルがありません。  別のフォルダを試してください。</translation>
+<translation>ソースフォルダーにファイルがありません。  別のフォルダーを試してください。</translation>
 </phrase>
 
 <phrase>
@@ -9624,12 +9623,12 @@ Repaired files have been saved to the destination folder.  Unrepaired files rema
 
 <phrase>
 <original>add entire folder(s)</original>
-<translation>フォルダ全体を追加</translation>
+<translation>フォルダー全体を追加</translation>
 </phrase>
 
 <phrase>
 <original>remove all images in this folder</original>
-<translation>このフォルダ内の画像をすべて除去</translation>
+<translation>このフォルダー内の画像をすべて除去</translation>
 </phrase>
 
 <phrase>
@@ -9639,12 +9638,12 @@ Repaired files have been saved to the destination folder.  Unrepaired files rema
 
 <phrase>
 <original>preserve input folder structure</original>
-<translation>入力フォルダ構造を保持</translation>
+<translation>入力フォルダー構造を保持</translation>
 </phrase>
 
 <phrase>
 <original>Select destination folder</original>
-<translation>保存先フォルダの選択</translation>
+<translation>保存先フォルダーの選択</translation>
 </phrase>
 
 <phrase>
@@ -9654,12 +9653,12 @@ Repaired files have been saved to the destination folder.  Unrepaired files rema
 
 <phrase>
 <original>add a prefix to each filename</original>
-<translation>各ファイル名に接頭辞を付ける</translation>
+<translation>各ファイル名の頭に文字列を付与する</translation>
 </phrase>
 
 <phrase>
 <original>add a suffix to each filename</original>
-<translation>各ファイル名に接尾辞を付ける</translation>
+<translation>各ファイル名の後ろに文字列を付与する</translation>
 </phrase>
 
 <phrase>
@@ -9669,7 +9668,7 @@ Repaired files have been saved to the destination folder.  Unrepaired files rema
 
 <phrase>
 <original>force each filename, including extension, to the following case</original>
-<translation>拡張子を含む各ファイル名を以下のケースに強制的に変換</translation>
+<translation>拡張子を含む各ファイル名を次のように強制的に変換</translation>
 </phrase>
 
 <phrase>
@@ -9694,12 +9693,12 @@ Repaired files have been saved to the destination folder.  Unrepaired files rema
 
 <phrase>
 <original>additional rename options</original>
-<translation>リネームの追加オプション</translation>
+<translation>追加の名前変更オプション</translation>
 </phrase>
 
 <phrase>
 <original>output images to this folder</original>
-<translation>このフォルダに画像を出力</translation>
+<translation>このフォルダーに画像を出力</translation>
 </phrase>
 
 <phrase>
@@ -9764,7 +9763,7 @@ Repaired files have been saved to the destination folder.  Unrepaired files rema
 
 <phrase>
 <original>previews disabled</original>
-<translation>プレビュー無効</translation>
+<translation>プレビューが無効です</translation>
 </phrase>
 
 <phrase>
@@ -9781,7 +9780,7 @@ Repaired files have been saved to the destination folder.  Unrepaired files rema
 <original>If you exit now, your batch list (the list of images to be processed) will be lost.  By saving your list, you can easily resume this batch operation at a later date.
 
 Would you like to save your batch list before exiting?</original>
-<translation>ここで終了すると、バッチ リスト (処理する画像のリスト) は失われます。  リストを保存しておけば、後日簡単にバッチ処理を再開できます。
+<translation>ここで終了すると、バッチ リスト (処理する画像のリスト) が失われます。  リストを保存すると、後でこのバッチ操作を簡単に再開できます。
 
 終了する前にバッチ リストを保存しますか?</translation>
 </phrase>
@@ -9798,7 +9797,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>You have already created a list of images for processing.  The list of images inside this file will be appended to the bottom of your current list.</original>
-<translation>処理する画像のリストはすでに作成されています。  このファイル内の画像リストは、現在のリストの下に追加されます。</translation>
+<translation>処理する画像のリストはすでに作成されています。  このファイル内の画像のリストは、現在のリストの最後に追加されます。</translation>
 </phrase>
 
 <phrase>
@@ -9828,7 +9827,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>No macro file selected</original>
-<translation>マクロ ファイルが選択されていない</translation>
+<translation>マクロ ファイルが選択されていません</translation>
 </phrase>
 
 <phrase>
@@ -9838,77 +9837,77 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>No images selected</original>
-<translation>画像が選択されていない</translation>
+<translation>画像が選択されていません</translation>
 </phrase>
 
 <phrase>
 <original>Before proceeding, you need to click the "set export settings for this format" button to specify what export settings you want to use.</original>
-<translation>次に進む前に、"Set export settings for this format "ボタンをクリックして、使用するエクスポート設定を指定する必要があります。</translation>
+<translation>続行する前に、[この形式のエクスポート設定を設定する] ボタンをクリックして、使用するエクスポート設定を指定する必要があります。</translation>
 </phrase>
 
 <phrase>
 <original>Export settings required</original>
-<translation>必要なエクスポート設定</translation>
+<translation>エクスポート設定が必要です</translation>
 </phrase>
 
 <phrase>
 <original>PhotoDemon cannot access the requested output folder.  Please select a non-system, unrestricted folder for the batch process.</original>
-<translation>PhotoDemon は要求された出力フォルダにアクセスできません。  バッチ処理のために、非システム、制限のないフォルダを選択してください。</translation>
+<translation>PhotoDemon は要求された出力フォルダーにアクセスできません。  バッチ処理にはシステム以外の制限のないフォルダーを選択してください。</translation>
 </phrase>
 
 <phrase>
 <original>Folder access unavailable</original>
-<translation>フォルダにアクセスできません</translation>
+<translation>フォルダーにアクセスできません</translation>
 </phrase>
 
 <phrase>
 <original>Start processing!</original>
-<translation>処理を開始する!</translation>
+<translation>処理を開始!</translation>
 </phrase>
 
 <phrase>
 <original>Welcome to PhotoDemon's batch wizard.  This tool can be used to edit multiple images at once, in what is called a "batch process".</original>
-<translation>PhotoDemon のバッチ ウィザードへようこそ。  このツールは、複数の画像を一度に編集する "バッチ処理" が行えます。</translation>
+<translation>PhotoDemon のバッチ ウィザードへようこそ。  このツールを使用すると、いわゆる「バッチ処理」で複数の画像を一度に編集できます。</translation>
 </phrase>
 
 <phrase>
 <original>Start by selecting the photo editing action(s) you want to apply.  If multiple actions are selected, they will be applied in the order they appear on this page.</original>
-<translation>適用したい写真編集アクションを選択します。  複数のアクションを選択した場合は、このページに表示されている順番に適用されます。</translation>
+<translation>まず、適用する写真編集アクションを選択します。  複数のアクションが選択されている場合、それらはこのページに表示される順序で適用されます。</translation>
 </phrase>
 
 <phrase>
-<original>Note: a "macro" is simply a list of photo editing actions.  It can include any adjustment, filter, or effect in the main program.  You can create a new macro by using the "Tools -> Macros -> Record new macro" menu in the main PhotoDemon window.</original>
-<translation>注: 「マクロ」とは、単に写真の編集アクションのリストのことです。  メイン プログラムの調整、フィルター、またはエフェクトを含むことができます。  PhotoDemon のメイン ウィンドウの 「[ツール] -> [マクロを作成] -> [記録を開始]」 メニューを使用して、新しいマクロを作成できます。</translation>
+<original>Note: a "macro" is simply a list of photo editing actions.  It can include any adjustment, filter, or effect in the main program.  You can create a new macro by using the "Tools -&gt; Macros -&gt; Record new macro" menu in the main PhotoDemon window.</original>
+<translation>注: 「マクロ」とは、単に写真編集アクションのリストです。メイン プログラムには、任意の調整、フィルター、エフェクトを含めることができます。  PhotoDemon のメイン ウィンドウの [ツール] -&gt; [マクロを作成] -&gt; [記録を開始] メニューを使用して、新しいマクロを作成できます。</translation>
 </phrase>
 
 <phrase>
 <original>In the next step, you will select the images you want to process.</original>
-<translation>次のステップでは、処理したい画像を選択します。</translation>
+<translation>次のステップでは、処理する画像を選択します。</translation>
 </phrase>
 
 <phrase>
 <original>Step 2: prepare the batch list (the list of images to be processed)</original>
-<translation>ステップ 2: バッチ リスト (処理する画像のリスト) を用意</translation>
+<translation>ステップ2: バッチリスト（処理する画像のリスト）を準備する</translation>
 </phrase>
 
 <phrase>
 <original>You can add files to the batch list in two ways</original>
-<translation>バッチ リストにファイルを追加するには、次の 2 つの方法があります</translation>
+<translation>2 つの方法でファイルをバッチ リストに追加できます。</translation>
 </phrase>
 
 <phrase>
 <original>1) By manually adding one or more image file(s) using a standard Open Image dialog.</original>
-<translation>1) 標準の「画像を開く」ダイアログを使用して、1つまたは複数の画像ファイルを手動で追加します。</translation>
+<translation>1) 標準の「画像を開く」ダイアログを使用して、1 つ以上の画像ファイルを手動で追加します。</translation>
 </phrase>
 
 <phrase>
 <original>2) By adding entire folders at once.  Image file(s) inside the folder (or subfolders, if selected) will be automatically identified.</original>
-<translation>2) フォルダー全体を一度に追加する方法。  フォルダ (選択されている場合はサブ フォルダ) 内の画像ファイルは自動的に識別されます。</translation>
+<translation>2) フォルダー全体を一度に追加します。フォルダー (選択した場合はサブフォルダー) 内の画像ファイルが自動的に識別されます。</translation>
 </phrase>
 
 <phrase>
 <original>In the next step, you will choose how you want the processed images saved.</original>
-<translation>次のステップでは、処理した画像の保存方法を選択します。</translation>
+<translation>次のステップでは、処理した画像を保存する方法を選択します。</translation>
 </phrase>
 
 <phrase>
@@ -9918,17 +9917,17 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>PhotoDemon needs to know which format to use when saving the images in your batch list.</original>
-<translation>PhotoDemon は、バッチ リスト内の画像を保存する際に使用するフォーマットを知る必要があります。</translation>
+<translation>PhotoDemon は、バッチ リストに画像を保存するときにどのフォーマットを使用するかを認識する必要があります。</translation>
 </phrase>
 
 <phrase>
 <original>If "keep images in their original format" is selected, PhotoDemon will attempt to save each image in its original format.  If the original format is not supported, a standard format (JPEG or PNG, depending on color depth) will be used.</original>
-<translation>"画像を元のフォーマットのまま保存" が選択された場合、PhotoDemon は各画像を元のフォーマットで保存しようとします。  元のフォーマットがサポートされていない場合、標準のフォーマット (色深度により JPEG または PNG) が使用されます。</translation>
+<translation>"画像を元のフォーマットのまま保存" が選択されている場合、PhotoDemon は各画像を元の形式で保存しようとします。元の形式がサポートされていない場合は、標準形式 (色深度に応じて JPEG または PNG) が使用されます。</translation>
 </phrase>
 
 <phrase>
 <original>If you choose to save images to a new format, please make sure the format you have selected is appropriate for all images in your list.  (For example, images with transparency should be saved to a format that supports transparency!)</original>
-<translation>画像を新しいフォーマットで保存する場合は、選択したフォーマットがリスト内のすべての画像に適していることを確認してください。  (例えば、透明度のある画像は、透明度をサポートするフォーマットに保存する必要があります!)</translation>
+<translation>画像を新しい形式で保存する場合は、選択した形式がリスト内のすべての画像に適切であることを確認してください。  (たとえば、透明度のある画像は透明度をサポートする形式で保存する必要があります)</translation>
 </phrase>
 
 <phrase>
@@ -9938,7 +9937,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Step 4: provide a destination folder and any renaming options</original>
-<translation>ステップ 4: 保存先フォルダと任意のリネーム オプションを指定</translation>
+<translation>ステップ 4: 保存先フォルダーと名前変更のオプションを指定する</translation>
 </phrase>
 
 <phrase>
@@ -9953,12 +9952,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Finally, if two or more images in the batch list have the same filename, and the "original filenames" option is selected, such files will automatically be given unique filenames upon saving (e.g. "original-filename (2)").</original>
-<translation>最後に、バッチ リスト内の 2 つ以上の画像のファイル名が同じで、"元のファイル名" オプションが選択されている場合、そのようなファイルは保存時に自動的に一意のファイル名が付けられます ("元のファイル名 (2) "など)。</translation>
+<translation>最後に、バッチ リスト内の 2 つ以上の画像が同じファイル名を持ち、“元のファイル名” オプションが選択されている場合、そのようなファイルには保存時に自動的に一意のファイル名が付けられます (“元のファイル名 (2)” など)。</translation>
 </phrase>
 
 <phrase>
 <original>Step 5: wait for batch processing to finish</original>
-<translation>ステップ 5: バッチ処理の終了を待っています</translation>
+<translation>ステップ 5: バッチ処理が完了するまで待ちます</translation>
 </phrase>
 
 <phrase>
@@ -9968,12 +9967,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Once the batch processor has processed several images, it will display an estimated time remaining.</original>
-<translation>バッチ プロセッサーが数枚の画像を処理すると、残り時間の目安が表示されます。</translation>
+<translation>バッチ プロセッサーが数枚の画像を処理すると、推定の残り時間が表示されます。</translation>
 </phrase>
 
 <phrase>
 <original>You can cancel batch processing at any time by pressing the "Cancel" button in the bottom-right corner.  If you choose to cancel, any processed images will still be present in the output folder, so you may need to remove them manually.</original>
-<translation>バッチ処理は、右下の "キャンセル" ボタンを押すことで、いつでもキャンセルできます。  キャンセルを選択した場合でも、処理済みの画像は出力フォルダに残っているため、手動で削除する必要があります。</translation>
+<translation>右下の “キャンセル” ボタンを押せば、いつでもバッチ処理をキャンセルできます。  キャンセルを選択した場合、処理された画像は出力フォルダーにまだ存在するため、手動で削除する必要がある場合があります。</translation>
 </phrase>
 
 <phrase>
@@ -9983,7 +9982,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>You haven't selected any image files.  Please add one or more files to the batch list before saving.</original>
-<translation>画像ファイルが選択されていません。  保存する前に、1 つ以上のファイルをバッチ リストに追加してください。</translation>
+<translation>画像ファイルが選択されていません。  保存する前に、バッチ リストに 1 つ以上のファイルを追加してください。</translation>
 </phrase>
 
 <phrase>
@@ -10018,7 +10017,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Ascending numbers (1, 2, 3, etc.)</original>
-<translation>昇順の数字 (1、2、3など)</translation>
+<translation>昇順の数字 (1、2、3 など)</translation>
 </phrase>
 
 <phrase>
@@ -10028,7 +10027,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>( specifically, JPEG at 92% quality for photographs, and lossless PNG for non-photographs )</original>
-<translation>(具体的には、写真の場合は92%の画質のJPEG、写真以外の場合はロスレスPNG)</translation>
+<translation>(具体的には、写真の場合は 92% 品質の JPEG、写真以外の場合はロスレス PNG)</translation>
 </phrase>
 
 <phrase>
@@ -10063,7 +10062,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Batch conversion canceled.  %1 image(s) were processed before cancelation.  Last processed image was "%2".</original>
-<translation>バッチ変換がキャンセルされました。  キャンセル前に %1 画像が処理されました。  最後に処理された画像は "%2" です。</translation>
+<translation>バッチ変換がキャンセルされました。 %1 個の画像がキャンセル前に処理されました。最後に処理された画像は “%2” です。</translation>
 </phrase>
 
 <phrase>
@@ -10073,7 +10072,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Estimating time remaining</original>
-<translation>残り時間の推定</translation>
+<translation>推定の残り時間</translation>
 </phrase>
 
 <!-- File_BatchWizard.frm contains 177 phrases. 74 were duplicates of existing phrases, so only 103 new phrases were written to file. -->
@@ -10090,7 +10089,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>advanced settings</original>
-<translation>詳細設定</translation>
+<translation>高度な設定</translation>
 </phrase>
 
 <phrase>
@@ -10154,12 +10153,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>balanced</original>
-<translation>中間</translation>
+<translation>バランス</translation>
 </phrase>
 
 <phrase>
 <original>best</original>
-<translation>最良</translation>
+<translation>最高</translation>
 </phrase>
 
 <!-- File_Export_AnimatedWebP.frm contains 22 phrases. 19 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
@@ -10188,7 +10187,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Palette export options</original>
-<translation>パレット書き出しオプション</translation>
+<translation>パレットのエクスポート オプション</translation>
 </phrase>
 
 <phrase>
@@ -10208,12 +10207,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>palette color count</original>
-<translation>パレット色数</translation>
+<translation>パレットの色数</translation>
 </phrase>
 
 <phrase>
 <original>palette contents</original>
-<translation>パレット内容</translation>
+<translation>パレットの内容</translation>
 </phrase>
 
 <phrase>
@@ -10223,7 +10222,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>current palette</original>
-<translation>カレントパレット</translation>
+<translation>現在のパレット</translation>
 </phrase>
 
 <phrase>
@@ -10233,17 +10232,17 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>overwrite</original>
-<translation>オーバーライト</translation>
+<translation>上書き</translation>
 </phrase>
 
 <phrase>
 <original>append</original>
-<translation>アペンド</translation>
+<translation>追加</translation>
 </phrase>
 
 <phrase>
 <original>Adobe Swatch Exchange (ASE) files can store multiple palettes inside a single file.  If you select the "append" option, PhotoDemon will add this palette to your existing ASE file.  Any palettes already inside the file will not be modified.</original>
-<translation>Adobe Swatch Exchange (ASE)ファイルは、1つのファイル内に複数のパレットを保存できます。  「追加」オプションを選択すると、PhotoDemon はこのパレットを既存のASEファイルに追加します。  既にファイル内にあるパレットは変更されません。</translation>
+<translation>Adobe 交換用スウォッチ (ASE) ファイルは、単一のファイル内に複数のパレットを保存できます。   「追加」オプションを選択すると、PhotoDemon はこのパレットを既存の ASE ファイルに追加します。  ファイル内にすでに存在するパレットは変更されません。</translation>
 </phrase>
 
 <!-- File_Export_Palette.frm contains 17 phrases. 5 were duplicates of existing phrases, so only 12 new phrases were written to file. -->
@@ -10292,7 +10291,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>currently available programs (listed by window title)</original>
-<translation>現在利用可能なプログラム (ウィンドウのタイトルで表示)</translation>
+<translation>現在利用可能なプログラム (ウィンドウ タイトルごとにリスト)</translation>
 </phrase>
 
 <phrase>
@@ -10307,7 +10306,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>screenshot source</original>
-<translation>スクリーンショット ソース</translation>
+<translation>スクリーンショットのソース</translation>
 </phrase>
 
 <phrase>
@@ -10317,7 +10316,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Target window required</original>
-<translation>対象ウィンドウが必要</translation>
+<translation>対象ウィンドウが必要です</translation>
 </phrase>
 
 <phrase>
@@ -10337,7 +10336,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Some programs (including Windows Store apps) do not allow direct screen captures.  If an application preview appears as a black square, you will need to take a full desktop screenshot, then manually crop the desired window region.</original>
-<translation>一部のプログラム (Windowsストアアプリを含む) では、画面を直接キャプチャすることができません。  アプリケーションのプレビューが黒い四角で表示される場合は、デスクトップ全体のスクリーンショットを撮影し、必要なウィンドウ領域を手動でトリミングする必要があります。</translation>
+<translation>一部のプログラム (Windows ストア アプリを含む) では、画面を直接キャプチャできません。  アプリケーションのプレビューが黒い四角として表示される場合は、デスクトップ全体のスクリーンショットを撮り、目的のウィンドウ領域を手動でトリミングする必要があります。</translation>
 </phrase>
 
 <phrase>
@@ -10391,22 +10390,22 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Sending image to printer</original>
-<translation>プリンタへの画像送信</translation>
+<translation>画像をプリンターに送信しています</translation>
 </phrase>
 
 <phrase>
 <original>Image printed successfully. (Note: depending on your printer, additional print confirmation screens may appear.)</original>
-<translation>画像が正常に印刷されました。(注: プリンタによっては、追加の印刷確認画面が表示される場合があります)</translation>
+<translation>画像は正常に印刷されました。 (注: お使いのプリンターによっては、追加の印刷確認画面が表示される場合があります)</translation>
 </phrase>
 
 <phrase>
 <original>%1 was unable to print the image.  Please make sure that the specified printer (%2) is powered-on and ready for printing.</original>
-<translation>%1 は画像を印刷できませんでした。  指定されたプリンタ (%2) の電源が入っていて、印刷できる状態になっていることを確認してください。</translation>
+<translation>%1 は画像を印刷できませんでした。指定されたプリンター (%2) の電源が入っており、印刷できる状態であることを確認してください。</translation>
 </phrase>
 
 <phrase>
 <original>draft</original>
-<translation>草案</translation>
+<translation>下書き</translation>
 </phrase>
 
 <phrase>
@@ -10423,7 +10422,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>preview quality changes</original>
-<translation>プレビュー画質の変更</translation>
+<translation>品質の変更をプレビュー</translation>
 </phrase>
 
 <phrase>
@@ -10470,12 +10469,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>premultiply alpha</original>
-<translation>事前乗算アルファ</translation>
+<translation>アルファを事前乗算する</translation>
 </phrase>
 
 <phrase>
 <original>flip row order (top-down)</original>
-<translation>行のオーダーを反転 (上から下へ)</translation>
+<translation>行の順序を反転 (上から下)</translation>
 </phrase>
 
 <phrase>
@@ -10537,19 +10536,19 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>by cut-off</original>
-<translation>締め切り</translation>
+<translation>カットオフ</translation>
 </phrase>
 
 <phrase>
 <original>by color</original>
-<translation>色別</translation>
+<translation>色</translation>
 </phrase>
 
 <!-- File_Save_GIF.frm contains 20 phrases. 16 were duplicates of existing phrases, so only 4 new phrases were written to file. -->
 
 <phrase>
 <original>icon purpose</original>
-<translation>アイコン目的</translation>
+<translation>アイコンの目的</translation>
 </phrase>
 
 <phrase>
@@ -10626,7 +10625,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Super compression, very poor image quality (256:1)</original>
-<translation>超圧縮で画質が非常に悪い (256:1)</translation>
+<translation>超圧縮、非常に悪い画質 (256:1)</translation>
 </phrase>
 
 <phrase>
@@ -10648,7 +10647,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>perfect (99)</original>
-<translation>パーフェクト (99)</translation>
+<translation>完璧 (99)</translation>
 </phrase>
 
 <phrase>
@@ -10683,7 +10682,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>optimized baseline</original>
-<translation>最適化ベースライン</translation>
+<translation>最適化されたベースライン</translation>
 </phrase>
 
 <phrase>
@@ -10693,12 +10692,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>low (default)</original>
-<translation>低い (既定)</translation>
+<translation>カラー (24-bpp)</translation>
 </phrase>
 
 <phrase>
 <original>color (24-bpp)</original>
-<translation>カラー (24bpp)</translation>
+<translation>白黒 (8-bpp)</translation>
 </phrase>
 
 <phrase>
@@ -10710,7 +10709,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>use progressive encoding</original>
-<translation>プログレッシブエンコーディングを使用</translation>
+<translation>プログレッシブ エンコーディングを使用</translation>
 </phrase>
 
 <phrase>
@@ -10730,12 +10729,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>High compression, poor image quality (40)</original>
-<translation>高圧縮、画質が悪い (40)</translation>
+<translation>高圧縮、低画質 (40)</translation>
 </phrase>
 
 <phrase>
 <original>Super compression, very poor image quality (20)</original>
-<translation>超圧縮、非常に画質が悪い (20)</translation>
+<translation>超圧縮、非常に悪い画質 (20)</translation>
 </phrase>
 
 <!-- File_Save_JXR.frm contains 16 phrases. 10 were duplicates of existing phrases, so only 6 new phrases were written to file. -->
@@ -10779,22 +10778,22 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>compression optimization</original>
-<translation>圧縮最適化</translation>
+<translation>圧縮の最適化</translation>
 </phrase>
 
 <phrase>
 <original>fast, larger file</original>
-<translation>高速、大容量ファイル</translation>
+<translation>高速、大きいファイル</translation>
 </phrase>
 
 <phrase>
 <original>embed background color (bKGD chunk)</original>
-<translation>埋め込み背景色 (bKGDチャンク)</translation>
+<translation>背景色を埋め込む (bKGD チャンク)</translation>
 </phrase>
 
 <phrase>
 <original>slow, smaller file</original>
-<translation>ファイルサイズが小さい</translation>
+<translation>低速、小さいファイル</translation>
 </phrase>
 
 <phrase>
@@ -10809,32 +10808,32 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>single filter: none</original>
-<translation>シングル フィルター: なし</translation>
+<translation>単一フィルター: なし</translation>
 </phrase>
 
 <phrase>
 <original>single filter: sub</original>
-<translation>シングル フィルター: サブ</translation>
+<translation>単一フィルター: サブ</translation>
 </phrase>
 
 <phrase>
 <original>single filter: up</original>
-<translation>シングル フィルター: 上</translation>
+<translation>単一フィルター: 上</translation>
 </phrase>
 
 <phrase>
 <original>single filter: average</original>
-<translation>シングル フィルター: 平均</translation>
+<translation>単一フィルター: 平均</translation>
 </phrase>
 
 <phrase>
 <original>single filter: paeth</original>
-<translation>シングル フィルター: ペース</translation>
+<translation>単一フィルター: ペース</translation>
 </phrase>
 
 <phrase>
 <original>PNG files support different compression strategies (called "filters").  Smart filter selection produces better compression.  Use the automatic setting to have PhotoDemon test multiple strategies, and automatically select the one that produces the best compression.</original>
-<translation>PNG ファイルは、さまざまな圧縮方式 (「フィルタ」と呼ばれる) をサポートしています。  スマートなフィルタ選択は、より良い圧縮を生成します。  自動設定を使用して、PhotoDemon が複数の方式をテストし、自動的に最良の圧縮を生成するものを選択します。</translation>
+<translation>PNG ファイルは、さまざまな圧縮方式 (「フィルタ」と呼ばれる) をサポートしています。  スマートなフィルタ選択は、より良い圧縮を生成します。  自動設定を使用すると、PhotoDemon が複数の方式をテストし、自動的に最良の圧縮を生成するものを選択します。</translation>
 </phrase>
 
 <!-- File_Save_PNG.frm contains 22 phrases. 8 were duplicates of existing phrases, so only 14 new phrases were written to file. -->
@@ -10865,12 +10864,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>page format</original>
-<translation>ページ フォーマット</translation>
+<translation>ページ形式</translation>
 </phrase>
 
 <phrase>
 <original>single page (composited image)</original>
-<translation>単ページ (合成画像)</translation>
+<translation>単一ページ (合成画像)</translation>
 </phrase>
 
 <phrase>
@@ -10882,7 +10881,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>image type</original>
-<translation>画像タイプ</translation>
+<translation>画像の種類</translation>
 </phrase>
 
 <phrase>
@@ -10924,22 +10923,22 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>the fast, free, portable photo editor</original>
-<translation>高速で、無料で、ポータブルなフォト エディタ</translation>
+<translation>高速、無料、ポータブルなフォトエディター</translation>
 </phrase>
 
 <phrase>
 <original>Participate in development, design, or translation work</original>
-<translation>開発、デザイン、翻訳業務への参加</translation>
+<translation>開発、設計、翻訳作業に参加する</translation>
 </phrase>
 
 <phrase>
 <original>Download program source code</original>
-<translation>プログラムのソース コードをダウンロード</translation>
+<translation>プログラムのソース コードをダウンロードする</translation>
 </phrase>
 
 <phrase>
 <original>Review program and plugin licenses</original>
-<translation>プログラムとプラグインのライセンスを確認</translation>
+<translation>プログラムとプラグインのライセンスを確認する</translation>
 </phrase>
 
 <phrase>
@@ -10959,12 +10958,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>PhotoDemon is Copyright %1 2000-%2 by Tanner Helland and Contributors</original>
-<translation>PhotoDemon の著作権は、%1 2000-%2 Tanner Hellandおよびコントリビューターに帰属します。</translation>
+<translation>PhotoDemon: Copyright %1 2000-%2 Tanner Helland および貢献者</translation>
 </phrase>
 
 <phrase>
 <original>Donate to PhotoDemon development</original>
-<translation>PhotoDemon の開発に寄付</translation>
+<translation>PhotoDemon の開発に寄付する</translation>
 </phrase>
 
 <phrase>
@@ -10979,12 +10978,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Thank you to our wonderful Patreon supporters!</original>
-<translation>素晴らしいパトロン サポーターに感謝します!</translation>
+<translation>素晴らしいパトロン サポーターの皆様に感謝します!</translation>
 </phrase>
 
 <phrase>
 <original>(You can become a patron, too!  Click here to learn more.)</original>
-<translation>(あなたもパトロンになれます! 詳しくはこちらをクリック)</translation>
+<translation>(あなたもパトロンになれます! 詳しくはこちらをクリックしてください)</translation>
 </phrase>
 
 <!-- Help_About.frm contains 23 phrases. 9 were duplicates of existing phrases, so only 14 new phrases were written to file. -->
@@ -11070,7 +11069,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>As a rough estimate, these images are %1% similar.</original>
-<translation>大まかに見積もって、これらの画像は %1% 似ています。</translation>
+<translation>大まかな推定として、これらの画像は %1% 類似しています。</translation>
 </phrase>
 
 <phrase>
@@ -11087,12 +11086,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Initializing content-aware resize engine</original>
-<translation>コンテンツ認識リサイズ エンジンの初期化</translation>
+<translation>コンテンツに応じたリサイズ エンジンを初期化しています</translation>
 </phrase>
 
 <phrase>
 <original>Applying content-aware resize</original>
-<translation>コンテンツに応じたリサイズの適用</translation>
+<translation>コンテンツに応じたリサイズを適用しています</translation>
 </phrase>
 
 <!-- Image_ContentAwareResize.frm contains 12 phrases. 9 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
@@ -11103,20 +11102,20 @@ Would you like to save your batch list before exiting?</original>
 </phrase>
 
 <phrase>
-<original>add this to the "Adjustments > Color > Color lookup" tool</original>
-<translation>[調整] > [カラー] > [カラー ルックアップ]ツールに追加</translation>
+<original>add this to the "Adjustments &gt; Color &gt; Color lookup" tool</original>
+<translation>これを [調整] &gt; [カラー] &gt; [カラー ルックアップ] ツールに追加</translation>
 </phrase>
 
 <phrase>
 <original>modified image and layer</original>
-<translation>修正画像とレイヤー</translation>
+<translation>変更された画像とレイヤー</translation>
 </phrase>
 
 <!-- Image_CreateLUT.frm contains 20 phrases. 17 were duplicates of existing phrases, so only 3 new phrases were written to file. -->
 
 <phrase>
 <original>tools</original>
-<translation>用具</translation>
+<translation>ツール</translation>
 </phrase>
 
 <phrase>
@@ -11141,7 +11140,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Generate full metadata report (HTML)</original>
-<translation>フル メタデータ レポート (HTML) の作成</translation>
+<translation>完全なメタデータ レポート (HTML) を生成</translation>
 </phrase>
 
 <phrase>
@@ -11156,7 +11155,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>%1 groups in this image</original>
-<translation>この画像に %1 個のグループ</translation>
+<translation>この画像には %1 個のグループがあります</translation>
 </phrase>
 
 <phrase>
@@ -11166,17 +11165,17 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>edit tags</original>
-<translation>編集タグ</translation>
+<translation>タグを編集する</translation>
 </phrase>
 
 <phrase>
 <original>editor options</original>
-<translation>エディタオプション</translation>
+<translation>エディターのオプション</translation>
 </phrase>
 
 <phrase>
 <original>Mark this tag for removal</original>
-<translation>このタグに削除マークを付ける</translation>
+<translation>このタグを削除対象としてマーク</translation>
 </phrase>
 
 <phrase>
@@ -11191,7 +11190,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Mark this entire group for removal</original>
-<translation>このグループ全体に削除マークを付ける</translation>
+<translation>このグループ全体を削除対象としてマーク</translation>
 </phrase>
 
 <phrase>
@@ -11211,52 +11210,52 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>1 tag in this category</original>
-<translation>このカテゴリに 1 個のタグ</translation>
+<translation>このカテゴリには 1 つのタグが含まれます</translation>
 </phrase>
 
 <phrase>
 <original>%1 tags in this category</original>
-<translation>このカテゴリに %1 個のタグ</translation>
+<translation>このカテゴリには %1 個のタグがあります</translation>
 </phrase>
 
 <phrase>
 <original>no tags in this category</original>
-<translation>このカテゴリのタグはありません</translation>
+<translation>このカテゴリにはタグがありません</translation>
 </phrase>
 
 <phrase>
 <original>"System" tags are provided by the operating system.  They are not embedded as traditional metadata.</original>
-<translation>「システム」タグは、オペレーティング システムによって提供されます。  従来のメタデータとしては埋め込まれていなません。</translation>
+<translation>「システム」タグはオペレーティング システムによって提供されます。  従来のメタデータとして埋め込まれません。</translation>
 </phrase>
 
 <phrase>
 <original>"File" tags are required by this image format.  They are not embedded as traditional metadata.</original>
-<translation>「ファイル "タグは、この画像フォーマットでは必須です。  従来のメタデータとしては埋め込まれていません。</translation>
+<translation>この画像形式では “File” タグが必要です。これらは従来のメタデータとして埋め込まれません。</translation>
 </phrase>
 
 <phrase>
 <original>ICC profiles are handled automatically by PhotoDemon.  They are not embedded as traditional metadata.</original>
-<translation>ICC プロファイルは、PhotoDemonによって自動的に処理されます。  それらは従来のメタデータとして埋め込まれません。</translation>
+<translation>ICC プロファイルは PhotoDemon によって自動的に処理されます。  これらは従来のメタデータとして埋め込まれません。</translation>
 </phrase>
 
 <phrase>
 <original>"Inferred" tags are hypothetical values inferred from other metadata.  They are not embedded as traditional metadata.</original>
-<translation>"Inferred" タグは、他のメタデータから推測される仮説的な値です。  従来のメタデータとして埋め込まれることはありません。</translation>
+<translation>"Inferred" タグは、他のメタデータから推論された仮説的な値です。  これらは従来のメタデータとして埋め込まれません。</translation>
 </phrase>
 
 <phrase>
 <original>tag restrictions</original>
-<translation>タグ制限</translation>
+<translation>タグの制限</translation>
 </phrase>
 
 <phrase>
 <original>This is a protected tag.  Edits are allowed, but they may be overwritten to produce a valid image file.</original>
-<translation>これは保護されたタグです。  編集は許可されていますが、有効な画像ファイルを作成するために上書きされることがあります。</translation>
+<translation>これは保護されたタグです。  編集は許可されていますが、有効な画像ファイルを作成するために上書きされる可能性があります。</translation>
 </phrase>
 
 <phrase>
 <original>This tag is restricted.  It cannot be edited, and removal requests will be ignored if they result in an invalid file.</original>
-<translation>このタグは制限されています。  このタグは編集することができず、削除要求が無効なファイルになった場合は無視されます。</translation>
+<translation>このタグは制限されています。  編集することはできません。また、削除リクエストによって無効なファイルが生成された場合、削除リクエストは無視されます。</translation>
 </phrase>
 
 <phrase>
@@ -11270,8 +11269,8 @@ Would you like to save your batch list before exiting?</original>
 </phrase>
 
 <phrase>
-<original>integers >= 0</original>
-<translation>整数 >= 0</translation>
+<original>integers &gt;= 0</original>
+<translation>整数 &gt;= 0</translation>
 </phrase>
 
 <phrase>
@@ -11280,8 +11279,8 @@ Would you like to save your batch list before exiting?</original>
 </phrase>
 
 <phrase>
-<original>numbers >= 0</original>
-<translation>数値 >= 0</translation>
+<original>numbers &gt;= 0</original>
+<translation>数値 &gt;= 0</translation>
 </phrase>
 
 <phrase>
@@ -11326,7 +11325,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>%1 numbers max</original>
-<translation>最大 %1</translation>
+<translation>最大 %1 個の数値</translation>
 </phrase>
 
 <phrase>
@@ -11338,7 +11337,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>preview changes</original>
-<translation>プレビューの変更</translation>
+<translation>変更のプレビュー</translation>
 </phrase>
 
 <phrase>
@@ -11373,17 +11372,17 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Some image resampling filters support approximate calculations.  These improve performance at a minor penalty to quality.</original>
-<translation>一部の画像リサンプリングフィルタは近似計算をサポートしています。  これらは、わずかな品質への影響と引き換えに、パフォーマンスを向上させます。</translation>
+<translation>一部の画像リサンプリング フィルターは近似計算をサポートしています。これらにより、品質は若干犠牲になりますが、パフォーマンスが向上します。</translation>
 </phrase>
 
 <phrase>
 <original>Resampling affects the quality of a resized image.  For a good summary of resampling techniques, visit the Image Resampling article on Wikipedia.</original>
-<translation>リサンプリングは、リサイズされた画像の品質に影響を与えます。  リサンプリング技術に関する優れた要約は、Wikipedia の画像リサンプリングの記事をご覧ください。</translation>
+<translation>リサンプリングは、サイズ変更された画像の品質に影響します。  リサンプリング手法の概要については、Wikipedia の画像リサンプリングの記事を参照してください。</translation>
 </phrase>
 
 <phrase>
 <original>When changing an image's aspect ratio, undesirable stretching may occur.  PhotoDemon can avoid this by using empty borders or cropping instead.</original>
-<translation>画像のアスペクト比を変更する場合、望ましくない伸張が発生することがあります。  PhotoDemon は、余白またはトリミングを代わりに使用することにより、これを避けることができます。</translation>
+<translation>画像のアスペクト比を変更する場合、望ましくない伸張が発生することがあります。  PhotoDemon では、代わりに余白またはトリミングを使用することにより、これを回避できます。</translation>
 </phrase>
 
 <phrase>
@@ -11498,7 +11497,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>after importing source images</original>
-<translation>ソース画像をインポートした後</translation>
+<translation>元の画像をインポートした後</translation>
 </phrase>
 
 <phrase>
@@ -11508,7 +11507,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>align imported layers</original>
-<translation>インポートしたレイヤーを揃える</translation>
+<translation>インポートしたレイヤーを整列</translation>
 </phrase>
 
 <phrase>
@@ -11523,7 +11522,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>source image(s)</original>
-<translation>ソース画像</translation>
+<translation>元の画像</translation>
 </phrase>
 
 <phrase>
@@ -11533,12 +11532,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>resize to fit imported layers</original>
-<translation>インポートしたレイヤーに合わせてサイズを変更</translation>
+<translation>インポートしたレイヤーに合わせてリサイズ</translation>
 </phrase>
 
 <phrase>
 <original>replace existing layers with imported ones</original>
-<translation>既存のレイヤーをインポートしたレイヤーに置き換える</translation>
+<translation>既存のレイヤーをインポートしたレイヤーに置換</translation>
 </phrase>
 
 <phrase>
@@ -11548,17 +11547,17 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>leave images open</original>
-<translation>画像をオープンにしておく</translation>
+<translation>画像を開いたままにしておく</translation>
 </phrase>
 
 <phrase>
 <original>close images normally (prompt for unsaved changes)</original>
-<translation>画像を普通に閉じる (未保存の変更はプロンプトを表示)</translation>
+<translation>通常どおり画像を閉じる (未保存の変更は確認する)</translation>
 </phrase>
 
 <phrase>
 <original>close images without prompting</original>
-<translation>プロンプトなしで画像を閉じる</translation>
+<translation>確認なしで画像を閉じる</translation>
 </phrase>
 
 <!-- Layer_Split_ImagesToLayers.frm contains 15 phrases. 2 were duplicates of existing phrases, so only 13 new phrases were written to file. -->
@@ -11645,7 +11644,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Click: delete this layer</original>
-<translation>クリック: このレイヤーを削除する</translation>
+<translation>クリック: このレイヤーを削除</translation>
 </phrase>
 
 <phrase>
@@ -11655,7 +11654,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Shift + Click: merge this layer with the layer above it</original>
-<translation>Shift + クリック: このレイヤーとその上のレイヤーを結合します</translation>
+<translation>Shift + クリック: このレイヤーとその上を結合</translation>
 </phrase>
 
 <phrase>
@@ -11670,17 +11669,17 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Shift + Click: merge this layer with the layer beneath it</original>
-<translation>Shift + クリック: このレイヤーとその下のレイヤーを統合する</translation>
+<translation>Shift + クリック: このレイヤーとその下を統合</translation>
 </phrase>
 
 <phrase>
 <original>Move or merge layer down</original>
-<translation>レイヤーを下に移動またはマージする</translation>
+<translation>レイヤーを下に移動または結合</translation>
 </phrase>
 
 <phrase>
 <original>Click: add a duplicate of this layer</original>
-<translation>クリック: このレイヤーの複製を追加する</translation>
+<translation>クリック: このレイヤーの複製を追加</translation>
 </phrase>
 
 <phrase>
@@ -11784,8 +11783,8 @@ Would you like to save your batch list before exiting?</original>
 </phrase>
 
 <phrase>
-<original>This option will create a blank image.  Other ways to create new images can be found in the File -> Import menu.</original>
-<translation>このオプションは空白の画像を作成します。  新規画像を作成する他の方法は、[ファイル] -> [インポート] メニューにあります。</translation>
+<original>This option will create a blank image.  Other ways to create new images can be found in the File -&gt; Import menu.</original>
+<translation>このオプションは空白の画像を作成します。  新規画像を作成する他の方法は、[ファイル] -&gt; [インポート] メニューにあります。</translation>
 </phrase>
 
 <phrase>
@@ -11805,7 +11804,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>If the current image has not been saved, you will receive a prompt to save it before it closes.</original>
-<translation>現在の画像が保存されていない場合、閉じる前に保存を促すプロンプトが表示されます。</translation>
+<translation>現在の画像が保存されていない場合、閉じる前に保存の確認プロンプトが表示されます。</translation>
 </phrase>
 
 <phrase>
@@ -11814,8 +11813,8 @@ Would you like to save your batch list before exiting?</original>
 </phrase>
 
 <phrase>
-<original>Because you have turned off save prompts (via Edit -> Preferences), you WILL NOT receive a prompt to save this image before it closes.</original>
-<translation>保存プロンプトをオフにしている ([ツール] -> [オプション] で設定) ため、この画像を閉じる前に保存を促すプロンプトは表示されません。</translation>
+<original>Because you have turned off save prompts (via Edit -&gt; Preferences), you WILL NOT receive a prompt to save this image before it closes.</original>
+<translation>保存プロンプトをオフにしている ([ツール] -&gt; [オプション] で設定) ため、この画像を閉じる前に保存の確認プロンプトは表示されません。</translation>
 </phrase>
 
 <phrase>
@@ -11830,12 +11829,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>You have specified "safe" save mode, which means that each save will create a new file with an auto-incremented filename.</original>
-<translation>"セーフ" 保存モードが指定されているため、保存のたびに自動でファイル名の数字を 1 ずつ増やした、新しいファイルが作成されます。</translation>
+<translation>"安全な" 保存モードが指定されているため、保存のたびに自動でファイル名の数字を 1 ずつ増やした、新しいファイルが作成されます。</translation>
 </phrase>
 
 <phrase>
 <original>Use this to quickly save a lossless copy of the current image.  The lossless copy will be saved in PDI format, in the image's current folder, using the current filename (plus an auto-incremented number, as necessary).</original>
-<translation>この機能を使うと、現在の画像のロスレス コピーをすばやく保存できます。  ロスレス コピーは PDI 形式で、画像の現在のフォルダに、現在のファイル名 (必要に応じて自動インクリメントされる番号も追加されます)を使って保存されます。</translation>
+<translation>この機能を使うと、現在の画像のロスレス コピーをすばやく保存できます。  ロスレス コピーは PDI 形式で、画像の現在のフォルダーに、現在のファイル名 (必要に応じて自動で増加する番号も追加されます) を使って保存されます。</translation>
 </phrase>
 
 <phrase>
@@ -11850,7 +11849,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Save As (export to new format or filename)</original>
-<translation>名前を付けて保存 (新しいフォーマットまたはファイル名にエクスポートする)</translation>
+<translation>名前を付けて保存 (新しいフォーマットまたはファイル名にエクスポート)</translation>
 </phrase>
 
 <phrase>
@@ -11885,7 +11884,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Rectangular Selection</original>
-<translation>長方形の選択</translation>
+<translation>長方形選択</translation>
 </phrase>
 
 <phrase>
@@ -11925,7 +11924,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Paintbrush (soft-tipped brush)</original>
-<translation>絵筆 (穂先の柔らかいもの)</translation>
+<translation>絵筆 (先が柔らかい筆)</translation>
 </phrase>
 
 <phrase>
@@ -11935,7 +11934,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Paint bucket (fill with color)</original>
-<translation>ペンキ用バケツ (色を入れる)</translation>
+<translation>絵筆 (先が柔らかい筆)</translation>
 </phrase>
 
 <phrase>
@@ -11945,12 +11944,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Hand tool</original>
-<translation>ハンドツール</translation>
+<translation>ハンド ツール</translation>
 </phrase>
 
 <phrase>
 <original>Zoom tool</original>
-<translation>ズームツール</translation>
+<translation>ズーム ツール</translation>
 </phrase>
 
 <phrase>
@@ -11995,12 +11994,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Basic text tool</original>
-<translation>基本テキストツール</translation>
+<translation>基本テキスト ツール</translation>
 </phrase>
 
 <phrase>
 <original>Advanced text tool</original>
-<translation>高度なテキストツール</translation>
+<translation>高度なテキスト ツール</translation>
 </phrase>
 
 <phrase>
@@ -12010,7 +12009,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Paintbrush tool</original>
-<translation>ペイントブラシツール</translation>
+<translation>ペイントブラシ ツール</translation>
 </phrase>
 
 <phrase>
@@ -12020,19 +12019,19 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Clone stamp tool</original>
-<translation>クローンスタンプツール</translation>
+<translation>クローン スタンプ ツール</translation>
 </phrase>
 
 <phrase>
 <original>Paint bucket tool</original>
-<translation>ペイントバケツツール</translation>
+<translation>ペイント バケツ ツール</translation>
 </phrase>
 
 <!-- Toolbar_ToolSelect.frm contains 102 phrases. 41 were duplicates of existing phrases, so only 61 new phrases were written to file. -->
 
 <phrase>
 <original>pattern mode</original>
-<translation>パターンモード</translation>
+<translation>パターン モード</translation>
 </phrase>
 
 <phrase>
@@ -12123,22 +12122,22 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>brush style</original>
-<translation>筆記体</translation>
+<translation>ブラシ スタイル</translation>
 </phrase>
 
 <phrase>
 <original>tolerance</original>
-<translation>許容値</translation>
+<translation>許容範囲</translation>
 </phrase>
 
 <phrase>
 <original>compare pixels by</original>
-<translation>ピクセル単位で比較</translation>
+<translation>ピクセルで比較</translation>
 </phrase>
 
 <phrase>
 <original>fill area</original>
-<translation>塗りの領域</translation>
+<translation>塗りつぶし領域</translation>
 </phrase>
 
 <phrase>
@@ -12158,12 +12157,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Fills support many different styles.  Click to switch between solid color, pattern, and gradient styles.</original>
-<translation>塗りつぶしは様々なスタイルをサポートします。  クリックすると、無地、パターン、グラデーションのスタイルに切り替わります。</translation>
+<translation>塗りつぶしはさまざまなスタイルをサポートしています。  クリックして、単色、パターン、グラデーション スタイルを切り替えます。</translation>
 </phrase>
 
 <phrase>
 <original>Tolerance controls how similar two pixels must be before spreading the fill between them.</original>
-<translation>トレランスは、2 つのピクセルの間に塗りつぶしを広げる前に、2 つのピクセルがどの程度似ていなければならないかを制御します。</translation>
+<translation>許容値は、2 つのピクセル間に塗りつぶしを広げる前に、2 つのピクセルがどの程度類似している必要があるかを制御します。</translation>
 </phrase>
 
 <phrase>
@@ -12178,7 +12177,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>This option controls how pixels are analyzed when adding them to the fill.</original>
-<translation>このオプションは、塗りつぶしにピクセルを追加する際の解析方法を制御します。</translation>
+<translation>このオプションは、塗りつぶしにピクセルを追加する際の分析方法を制御します。</translation>
 </phrase>
 
 <!-- Toolpanel_Fill.frm contains 21 phrases. 8 were duplicates of existing phrases, so only 13 new phrases were written to file. -->
@@ -12314,12 +12313,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>position (x, y)</original>
-<translation>位置</translation>
+<translation>位置 (x, y)</translation>
 </phrase>
 
 <phrase>
 <original>shear (x, y)</original>
-<translation>せん断</translation>
+<translation>シアー (x, y)</translation>
 </phrase>
 
 <phrase>
@@ -12329,7 +12328,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Make layer changes permanent</original>
-<translation>レイヤーの変更を恒久的に</translation>
+<translation>レイヤーの変更を永続化</translation>
 </phrase>
 
 <phrase>
@@ -12344,7 +12343,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Make current layer transforms (size, angle, and shear) permanent.  This action is never required, but if viewport rendering is sluggish, it may improve performance.</original>
-<translation>現在のレイヤーの変形 (サイズ、角度、シアー) を永続化します。  このアクションは決して必要ではありませんが、ビューポートのレンダリングが遅い場合、パフォーマンスが向上する可能性があります。</translation>
+<translation>現在のレイヤーの変形 (サイズ、角度、シアー) を永続化します。  このアクションは必須ではありませんが、ビュー ポートのレンダリングが遅い場合、パフォーマンスが向上する可能性があります。</translation>
 </phrase>
 
 <!-- Toolpanel_MoveSize.frm contains 28 phrases. 10 were duplicates of existing phrases, so only 18 new phrases were written to file. -->
@@ -12360,7 +12359,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>(no additional options)</original>
-<translation>(追加のオプションなし)</translation>
+<translation>(追加のオプションはありません)</translation>
 </phrase>
 
 <phrase>
@@ -12455,12 +12454,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Lock this value.  (Only one value can be locked at a time.  If you lock a new value, previously locked values will unlock.)</original>
-<translation>この値をロックします。  (一度にロックできる値は1つだけです。  新しい値をロックすると、以前にロックされた値はロック解除されます)</translation>
+<translation>この値をロックします。  (一度にロックできる値は 1 つだけです。  新しい値をロックすると、以前にロックされていた値のロックが解除されます。)</translation>
 </phrase>
 
 <phrase>
 <original>This option controls how smoothly selection edges blend with their surroundings.</original>
-<translation>このオプションは、選択範囲のエッジが周囲とどの程度滑らかになじむかを制御します。</translation>
+<translation>このオプションは、選択範囲の境界が周囲とどの程度滑らかになじむかを制御します。</translation>
 </phrase>
 
 <phrase>
@@ -12474,8 +12473,8 @@ Would you like to save your batch list before exiting?</original>
 </phrase>
 
 <phrase>
-<original>This feathering slider allows for immediate feathering adjustments.  For performance reasons, it is limited to small radii.  For larger feathering radii, use the Select -> Feathering menu.</original>
-<translation>このぼかしスライダーは、ぼかしを即座に調整できます。  パフォーマンス上の理由から、小さな半径に制限されています。  ぼかしの半径を大きくするには、[選択] -> [ぼかし] メニューを使用します。</translation>
+<original>This feathering slider allows for immediate feathering adjustments.  For performance reasons, it is limited to small radii.  For larger feathering radii, use the Select -&gt; Feathering menu.</original>
+<translation>このぼかしスライダーは、ぼかしを即座に調整できます。  パフォーマンス上の理由から、小さな半径に制限されています。  ぼかしの半径を大きくするには、[選択] -&gt; [ぼかし] メニューを使用します。</translation>
 </phrase>
 
 <phrase>
@@ -12500,7 +12499,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Tolerance controls how similar a pixel must be to the target color before it is added to a magic wand selection.</original>
-<translation>トレランスは、ピクセルをマジック ワンドの選択範囲に加える前に、そのピクセルが対象の色にどれだけ似ているかをコントロールします。</translation>
+<translation>許容値は、ピクセルをマジック ワンドの選択範囲に加える前に、そのピクセルが対象の色にどれだけ似ていなければならないかを制御します。</translation>
 </phrase>
 
 <phrase>
@@ -12515,7 +12514,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>This option controls which criteria the magic wand uses to compare pixels to the target color.</original>
-<translation>このオプションは、マジック ワンドがピクセルを対象の色と比較する際に使用する基準をコントロールします。</translation>
+<translation>このオプションは、マジック ワンドがピクセルを対象の色と比較する際に使用する基準を制御します。</translation>
 </phrase>
 
 <!-- Toolpanel_Selections.frm contains 75 phrases. 42 were duplicates of existing phrases, so only 33 new phrases were written to file. -->
@@ -12669,7 +12668,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>traditional Chinese</original>
-<translation>繁体字</translation>
+<translation>繁体字中国語</translation>
 </phrase>
 
 <phrase>
@@ -12699,7 +12698,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Click here to convert this layer to advanced text.</original>
-<translation>このレイヤーを高度テキスト レイヤーに変換するには、ここをクリックしてください。</translation>
+<translation>このレイヤーを高度なテキストに変換するには、ここをクリックしてください。</translation>
 </phrase>
 
 <!-- Toolpanel_Typography.frm contains 60 phrases. 35 were duplicates of existing phrases, so only 25 new phrases were written to file. -->
@@ -12721,7 +12720,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>list of phrases (%1 items)</original>
-<translation>フレーズのリスト (%1 個)</translation>
+<translation>フレーズのリスト (%1 項目)</translation>
 </phrase>
 
 <phrase>
@@ -12756,12 +12755,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>(NOTE: CTRL+ENTER automatically saves and proceeds to next phrase.)</original>
-<translation>(注意: CTRL+ENTER で自動的に保存され、次のフレーズに進みます)</translation>
+<translation>(注: CTRL+ENTER を押すと自動的に保存され、次のフレーズに進みます。)</translation>
 </phrase>
 
 <phrase>
 <original>phrase types</original>
-<translation>フレーズのタイプ</translation>
+<translation>フレーズの種類</translation>
 </phrase>
 
 <phrase>
@@ -12776,7 +12775,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>status bar messages</original>
-<translation>ステータス バー</translation>
+<translation>ステータス バーのメッセージ</translation>
 </phrase>
 
 <phrase>
@@ -12786,7 +12785,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>files where this phrase occurs</original>
-<translation>このフレーズが用いられているファイル</translation>
+<translation>このフレーズが含まれるファイル</translation>
 </phrase>
 
 <phrase>
@@ -12831,7 +12830,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>optional translation aids</original>
-<translation>オプションの翻訳補助ツール</translation>
+<translation>オプションの翻訳補助</translation>
 </phrase>
 
 <phrase>
@@ -12851,12 +12850,12 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>These optional settings can accelerate the translation process.  They are not saved to the language file.</original>
-<translation>これらのオプション設定は、翻訳の作業を加速できます。 言語ファイルには保存されません。</translation>
+<translation>これらのオプション設定により、翻訳プロセスを高速化できます。  言語ファイルには保存されません。</translation>
 </phrase>
 
 <phrase>
 <original>delete selected language file</original>
-<translation>選択された言語を削除</translation>
+<translation>選択した言語ファイルを削除する</translation>
 </phrase>
 
 <phrase>
@@ -12876,7 +12875,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>Processing phrase %1 of %2</original>
-<translation>%2 個中 %1 個目のフレーズを処理中</translation>
+<translation>フレーズ %1 / %2 を処理しています</translation>
 </phrase>
 
 <phrase>
@@ -12896,7 +12895,7 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>You do not have access to this folder.  Please log in as an administrator and try again.</original>
-<translation>このフォルダにアクセスできません。 管理者としてログインし、再度お試しください。</translation>
+<translation>このフォルダーにアクセスできません。 管理者としてログインし、再度お試しください。</translation>
 </phrase>
 
 <phrase>
@@ -12911,14 +12910,14 @@ Would you like to save your batch list before exiting?</original>
 
 <phrase>
 <original>enter your name here</original>
-<translation>ここに名前を入力</translation>
+<translation>ここにあなたの名前を入力してください</translation>
 </phrase>
 
 <phrase>
 <original>Unfortunately, PhotoDemon's en-US language file could not be located on this PC.  This file is included with the official release of PhotoDemon, but it may not be included with development or beta builds.
 
 To start a new translation, please download a fresh copy of PhotoDemon from PhotoDemon.org.</original>
-<translation>残念ながら、PhotoDemon の en-Us 言語ファイルは、このpc上で見つけることができませんでした。  このファイルは、PhotoDemon の公式リリースに含まれていますが、開発またはベータビルドには含まれていない可能性があります。
+<translation>残念ながら、PhotoDemon の en-US 言語ファイルはこの PC 上に見つかりませんでした。  このファイルは PhotoDemon の正式リリースに含まれていますが、開発ビルドまたはベータ ビルドには含まれていない場合があります。
 
 新しい翻訳を開始するには、PhotoDemon.org から PhotoDemon の新しいコピーをダウンロードしてください。</translation>
 </phrase>
@@ -13004,7 +13003,7 @@ To continue, please download a fresh copy of PhotoDemon from PhotoDemon.org.</or
 
 <phrase>
 <original>[translation failed]</original>
-<translation>[翻訳失敗]</translation>
+<translation>[翻訳に失敗しました]</translation>
 </phrase>
 
 <phrase>
@@ -13014,22 +13013,22 @@ To continue, please download a fresh copy of PhotoDemon from PhotoDemon.org.</or
 
 <phrase>
 <original>unknown author</original>
-<translation>作者不詳</translation>
+<translation>作者不明</translation>
 </phrase>
 
 <phrase>
 <original>(official translation by %1)</original>
-<translation>(公式翻訳: %1)</translation>
+<translation>(%1 による公式翻訳)</translation>
 </phrase>
 
 <phrase>
 <original>by %1</original>
-<translation>by %1</translation>
+<translation>%1 作</translation>
 </phrase>
 
 <phrase>
 <original>(autosaved on %1)</original>
-<translation>(%1 で自動保存)</translation>
+<translation>(%1 に自動保存されました)</translation>
 </phrase>
 
 <!-- Tools_LanguageEditor.frm contains 108 phrases. 44 were duplicates of existing phrases, so only 64 new phrases were written to file. -->
@@ -13061,7 +13060,7 @@ To continue, please download a fresh copy of PhotoDemon from PhotoDemon.org.</or
 
 <phrase>
 <original>WARNING: this is not a valid macro.  The last action cannot occur after the first action.</original>
-<translation>警告: これは有効なマクロではありません。  最後のアクションは、最初のアクションの後に発生することはできません。</translation>
+<translation>警告: これは有効なマクロではありません。  最初のアクションの後に最後のアクションを実行することはできません。</translation>
 </phrase>
 
 <phrase>
@@ -13078,12 +13077,12 @@ To continue, please download a fresh copy of PhotoDemon from PhotoDemon.org.</or
 
 <phrase>
 <original>title bar text</original>
-<translation>タイトル バー テキスト</translation>
+<translation>タイトル バーのテキスト</translation>
 </phrase>
 
 <phrase>
 <original>maximum number of recent files to remember</original>
-<translation>最近使ったファイルの項目最大数</translation>
+<translation>記憶する最近使ったファイルの最大数</translation>
 </phrase>
 
 <phrase>
@@ -13103,7 +13102,7 @@ To continue, please download a fresh copy of PhotoDemon from PhotoDemon.org.</or
 
 <phrase>
 <original>grid colors</original>
-<translation>グリッド カラー</translation>
+<translation>グリッドの色</translation>
 </phrase>
 
 <phrase>
@@ -13118,12 +13117,12 @@ To continue, please download a fresh copy of PhotoDemon from PhotoDemon.org.</or
 
 <phrase>
 <original>when images arrive from an external source (like Windows Explorer)</original>
-<translation>画像を外部ソース (Windows エクスプローラなど) から届いた場合</translation>
+<translation>画像が外部ソース (Windows エクスプローラーなど) から届いた場合</translation>
 </phrase>
 
 <phrase>
 <original>display tone mapping options when importing HDR and RAW images</original>
-<translation>HDR および RAW 画像の読み込み時にトーン マッピングのオプションを表示する</translation>
+<translation>HDR および RAW 画像の読み込み時にトーン マッピングのオプションを表示</translation>
 </phrase>
 
 <phrase>
@@ -13133,12 +13132,12 @@ To continue, please download a fresh copy of PhotoDemon from PhotoDemon.org.</or
 
 <phrase>
 <original>high-dynamic range (HDR) images</original>
-<translation>ハイダイナミック レンジ (HDR)画像</translation>
+<translation>ハイダイナミック レンジ (HDR) 画像</translation>
 </phrase>
 
 <phrase>
 <original>forcibly extract binary-type tags as Base64 (slow)</original>
-<translation>バイナリ型タグを強制的に Base64 として抽出 (遅い)</translation>
+<translation>バイナリ型のタグを Base64 として強制的に抽出 (遅い)</translation>
 </phrase>
 
 <phrase>
@@ -13153,7 +13152,7 @@ To continue, please download a fresh copy of PhotoDemon from PhotoDemon.org.</or
 
 <phrase>
 <original>automatically hide duplicate tags</original>
-<translation>重複タグを自動的に隠す</translation>
+<translation>重複タグを自動的に非表示</translation>
 </phrase>
 
 <phrase>
@@ -13208,12 +13207,12 @@ To continue, please download a fresh copy of PhotoDemon from PhotoDemon.org.</or
 
 <phrase>
 <original>default folder</original>
-<translation>既定のフォルダ</translation>
+<translation>既定のフォルダー</translation>
 </phrase>
 
 <phrase>
 <original>when using "Save As", set the initial folder to</original>
-<translation>「名前を付けて保存」での初期フォルダ</translation>
+<translation>「名前を付けて保存」での初期フォルダー</translation>
 </phrase>
 
 <phrase>
@@ -13253,7 +13252,7 @@ To continue, please download a fresh copy of PhotoDemon from PhotoDemon.org.</or
 
 <phrase>
 <original>undo/redo</original>
-<translation>「元に戻す」と「やり直し」</translation>
+<translation>元に戻す/やり直す</translation>
 </phrase>
 
 <phrase>
@@ -13298,7 +13297,7 @@ To continue, please download a fresh copy of PhotoDemon from PhotoDemon.org.</or
 
 <phrase>
 <original>display policies</original>
-<translation>ディスプレイのポリシー</translation>
+<translation>ポリシーを表示</translation>
 </phrase>
 
 <phrase>
@@ -13318,7 +13317,7 @@ To continue, please download a fresh copy of PhotoDemon from PhotoDemon.org.</or
 
 <phrase>
 <original>memory usage will be displayed here</original>
-<translation>メモリ使用量はここに表示されます</translation>
+<translation>メモリー使用量がここに表示されます</translation>
 </phrase>
 
 <phrase>
@@ -13338,7 +13337,7 @@ To continue, please download a fresh copy of PhotoDemon from PhotoDemon.org.</or
 
 <phrase>
 <original>application settings folder</original>
-<translation>アプリケーション設定フォルダ</translation>
+<translation>アプリケーション設定フォルダー</translation>
 </phrase>
 
 <phrase>
@@ -13358,7 +13357,7 @@ To continue, please download a fresh copy of PhotoDemon from PhotoDemon.org.</or
 
 <phrase>
 <original>allow updates from these tracks</original>
-<translation>これらのトラックからのアップデートを許可</translation>
+<translation>これらのトラックからの更新を許可</translation>
 </phrase>
 
 <phrase>
@@ -13368,7 +13367,7 @@ To continue, please download a fresh copy of PhotoDemon from PhotoDemon.org.</or
 
 <phrase>
 <original>notify when an update is ready</original>
-<translation>アップデートの準備ができたら通知</translation>
+<translation>更新の準備ができたら通知</translation>
 </phrase>
 
 <phrase>
@@ -13407,7 +13406,7 @@ Are you sure you want to continue?</original>
 
 <phrase>
 <original>Loading</original>
-<translation>読み込み</translation>
+<translation>読み込み中</translation>
 </phrase>
 
 <phrase>
@@ -13447,7 +13446,7 @@ Are you sure you want to continue?</original>
 
 <phrase>
 <original>The "Recent Files" menu width is limited by Windows.  To prevent this menu from overflowing, PhotoDemon can display image names only instead of full image locations.</original>
-<translation>"最近使ったファイル" メニューの幅は、Windowsによって制限されています。  このメニューが溢れるのを防ぐために、PhotoDemon は、完全な画像位置の代わりに画像名のみを表示できます。</translation>
+<translation>“最近使ったファイル” メニューの幅は Windows によって制限されています。  このメニューがあふれるのを防ぐために、PhotoDemon では画像の完全な場所ではなく画像名のみを表示できます。</translation>
 </phrase>
 
 <phrase>
@@ -13457,7 +13456,7 @@ Are you sure you want to continue?</original>
 
 <phrase>
 <original>To help identify transparent pixels, a special grid appears "behind" them.  This setting modifies the grid's appearance.</original>
-<translation>透明ピクセルを識別しやすくするために、特別なグリッドがピクセルの「後ろ」に表示されます。  この設定は、グリッドの外観を変更します。</translation>
+<translation>透明なピクセルを識別しやすくするために、特別なグリッドがその「背面」に表示されます。  この設定により、グリッドの外観が変更されます。</translation>
 </phrase>
 
 <phrase>
@@ -13472,7 +13471,7 @@ Are you sure you want to continue?</original>
 
 <phrase>
 <original>HDR and RAW images contain more colors than PC screens can physically display.  Before displaying such images, a tone mapping operation must be applied to the original image data.</original>
-<translation>HDR 画像や RAW 画像には、PC の画面では物理的に表示できないほど多くの色が含まれています。  このような画像を表示する前に、元の画像データにトーン マッピング処理を施す必要があります。</translation>
+<translation>HDR および RAW 画像には、PC 画面が物理的に表示できるよりも多くの色が含まれています。  このような画像を表示する前に、元の画像データにトーン マッピング操作を適用する必要があります。</translation>
 </phrase>
 
 <phrase>
@@ -13487,32 +13486,32 @@ Are you sure you want to continue?</original>
 
 <phrase>
 <original>Older cameras and photo-editing software may not embed metadata correctly, leading to multiple metadata copies within a single file.  PhotoDemon can automatically resolve duplicate entries for you.</original>
-<translation>古いカメラおよび写真編集ソフトウェアは、メタデータを正しく埋め込むことができず、1つのファイル内に複数のメタデータをコピーしてしまうことがあります。  PhotoDemon は、自動的に重複エントリを解決します。</translation>
+<translation>古いカメラや写真編集ソフトウェアではメタデータが正しく埋め込まれていない可能性があり、単一ファイル内に複数のメタデータのコピーが作成されることがあります。   PhotoDemon は、重複したエントリを自動的に解決できます。</translation>
 </phrase>
 
 <phrase>
 <original>The JPEG format does not provide a way to store JPEG quality settings inside image files.  PhotoDemon can work around this by inferring quality settings from other metadata (like quantization tables).</original>
-<translation>JPEG フォーマットは、画像ファイル内に JPEG 品質設定を保存する方法を提供しません。  PhotoDemon は、他のメタデータ (量子化テーブルのような) から品質設定を推測することにより、これを回避できます。</translation>
+<translation>JPEG 形式では、画像ファイル内に JPEG 品質設定を保存する方法がありません。  PhotoDemon は、他のメタデータ (量子化テーブルなど) から品質設定を推測することで、この問題を回避できます。</translation>
 </phrase>
 
 <phrase>
 <original>Some camera manufacturers store proprietary metadata tags inside image files.  These tags are not generally useful to humans, but PhotoDemon can attempt to extract them anyway.</original>
-<translation>一部のカメラメーカーは、画像ファイル内に独自のメタデータタグを保存します。  これらのタグは、一般的に人間にとって有用ではありませんが、PhotoDemon はいずれにせよ抽出を試みることができます。</translation>
+<translation>一部のカメラ メーカーは、画像ファイル内に独自のメタデータ タグを保存しています。  これらのタグは一般に人間にとって役に立ちませんが、PhotoDemon はとにかくそれらの抽出を試みることができます。</translation>
 </phrase>
 
 <phrase>
 <original>By default, large binary tags (like image thumbnails) are not processed.  Instead, PhotoDemon simply reports the size of the embedded data.  If you require this data, PhotoDemon can manually convert it to Base64 for further analysis.</original>
-<translation>既定では、大きなバイナリ タグ (画像のサムネイルのような) は処理されません。  代わりに、PhotoDemon は単に埋め込まれたデータのサイズを報告します。  このデータが必要な場合、PhotoDemon はさらなる分析のために手動で Base64 に変換できます。</translation>
+<translation>デフォルトでは、大きなバイナリ タグ (画像のサムネイルなど) は処理されません。  代わりに、PhotoDemon は埋め込まれたデータのサイズを単純に報告します。このデータが必要な場合、PhotoDemon はさらに分析するためにデータを手動で Base64 に変換できます。</translation>
 </phrase>
 
 <phrase>
 <original>Most digital photos include rotation instructions (EXIF orientation metadata), which PhotoDemon will use to automatically rotate photos.  Some older smartphones and cameras may not write these instructions correctly, so if your photos are being imported sideways or upside-down, you can try disabling the auto-rotate feature.</original>
-<translation>ほとんどのデジタル写真には回転指示 (Exif 方向メタデータ) が含まれており、PhotoDemon はこれを使用して写真を自動的に回転させます。  古いスマートフォンやカメラの中には、これらの指示を正しく書き込まないものもありますので、写真が横向きや上下逆さまにインポートされる場合は、自動回転機能を無効にしてみてください。</translation>
+<translation>ほとんどのデジタル写真には回転命令 (EXIF 方向メタデータ) が含まれており、PhotoDemon はこれを使用して写真を自動的に回転します。  一部の古いスマートフォンやカメラではこれらの指示が正しく記述されていない可能性があるため、写真が横向きまたは逆さまにインポートされる場合は、自動回転機能を無効にしてみてください。</translation>
 </phrase>
 
 <phrase>
 <original>If your PC reboots while PhotoDemon is running, PhotoDemon can automatically restore your previous session.</original>
-<translation>PhotoDemon の実行中に PC が再起動した場合、PhotoDemon は自動的に以前のセッションを復元できます。</translation>
+<translation>PhotoDemon の実行中に PC が再起動すると、PhotoDemon は以前のセッションを自動的に復元します。</translation>
 </phrase>
 
 <phrase>
@@ -13522,32 +13521,32 @@ Are you sure you want to continue?</original>
 
 <phrase>
 <original>the current image's folder</original>
-<translation>現在の画像のフォルダ</translation>
+<translation>現在の画像のフォルダー</translation>
 </phrase>
 
 <phrase>
 <original>the last-used folder</original>
-<translation>最後に使用されたフォルダ</translation>
+<translation>最後に使用したフォルダー</translation>
 </phrase>
 
 <phrase>
 <original>Most photo editors default to the current image's folder.  For workflows that involve loading images from one folder but saving to a new folder, use the last-used folder to save time.</original>
-<translation>ほとんどのフォトエディタは、現在の画像のフォルダを既定としています。  あるフォルダから画像を読み込み、新しいフォルダに保存するようなワークフローでは、最後に使用したフォルダを使用すると時間を節約できます。</translation>
+<translation>ほとんどのフォト エディターは、デフォルトで現在の画像のフォルダーに設定されています。  1 つのフォルダーから画像を読み込み、新しいフォルダーに保存するワークフローの場合は、時間を節約するために最後に使用したフォルダーを使用します。</translation>
 </phrase>
 
 <phrase>
 <original>the current image's format</original>
-<translation>現在の画像のフォーマット</translation>
+<translation>現在の画像の形式</translation>
 </phrase>
 
 <phrase>
 <original>the last-used format</original>
-<translation>最後に使用されたフォーマット</translation>
+<translation>最後に使用した形式</translation>
 </phrase>
 
 <phrase>
 <original>Most photo editors default to the current image's format.  For workflows that involve loading images in one format (e.g. RAW) but saving to a new format (e.g. JPEG), use the last-used format to save time.</original>
-<translation>ほとんどのフォトエディタは、現在の画像フォーマットを既定としています。  あるフォーマット (例: RAW)で画像を読み込み、新しいフォーマット (例: JPEG)で保存するワークフローでは、時間を節約するために最後に使用したフォーマットを使用します。</translation>
+<translation>ほとんどのフォト エディターは、デフォルトで現在の画像の形式を使用します。  画像を 1 つの形式 (RAW など) で読み込み、新しい形式 (JPEG など) で保存するワークフローの場合は、時間を節約するために最後に使用した形式を使用します。</translation>
 </phrase>
 
 <phrase>
@@ -13557,17 +13556,17 @@ Are you sure you want to continue?</original>
 
 <phrase>
 <original>save a new copy, e.g. "filename (2).jpg" (safe behavior)</original>
-<translation>新しいコピーを保存、たとえば "ファイル名 (2).jpg" (安全な動作)</translation>
+<translation>新しいコピーを保存します。例: “ファイル名 (2).jpg” (安全な動作)</translation>
 </phrase>
 
 <phrase>
 <original>In most photo editors, the "Save" command saves the image over its original version, erasing that copy forever.  PhotoDemon provides a "safer" option, where each save results in a new copy of the file.</original>
-<translation>ほとんどのフォトエディタでは、"保存 "コマンドは、元のバージョンの上に画像を保存し、そのコピーを永遠に消去します。  PhotoDemon は、各保存がファイルの新しいコピーになる「より安全な」オプションを提供します。</translation>
+<translation>ほとんどのフォト エディターでは、”保存” コマンドを使用すると画像が元のバージョンに上書き保存され、そのコピーは永久に消去されます。  PhotoDemon は「より安全な」オプションを提供しており、保存するたびにファイルの新しいコピーが作成されます。</translation>
 </phrase>
 
 <phrase>
 <original>The EXIF specification asks programs to correctly identify themselves as the software of origin when exporting image files.  For increased privacy, you can suspend this behavior.</original>
-<translation>EXIF 仕様は、画像ファイルをエクスポートする際に、自分自身を元のソフトウェアとして正しく識別するようプログラムに要求します。  プライバシーを高めるために、この動作を一時停止できます。</translation>
+<translation>EXIF 仕様では、イメージ ファイルをエクスポートするときに、プログラム自身がオリジナルのソフトウェアであることを正しく識別するように求められます。  プライバシーを高めるために、この動作を一時停止できます。</translation>
 </phrase>
 
 <phrase>
@@ -13587,22 +13586,22 @@ Are you sure you want to continue?</original>
 
 <phrase>
 <original>Some interface elements receive custom decorations (like drop shadows).  On older PCs, these decorations can be suspended for a small performance boost.</original>
-<translation>一部のインターフェイス要素には、カスタム装飾 (ドロップシャドウなど) が施されています。  古いPC では、これらの装飾を一時停止することで、パフォーマンスを少し上げることができます。</translation>
+<translation>一部のインターフェイス要素には、カスタム装飾 (ドロップシャドウなど) が施されています。  古い PC では、これらの装飾を一時停止することで、パフォーマンスを少し上げることができます。</translation>
 </phrase>
 
 <phrase>
 <original>PhotoDemon generates many thumbnail images, especially when images contain multiple layers.  Thumbnail quality can be lowered to improve performance.</original>
-<translation>PhotoDemon は、特に画像が複数のレイヤーを含む場合、多くのサムネイル画像を生成します。  サムネイルの品質は、パフォーマンスを向上させるために下げることができます。</translation>
+<translation>PhotoDemon は、特に画像に複数のレイヤーが含まれている場合に、多くのサムネイル画像を生成します。  パフォーマンスを向上させるためにサムネイルの品質を下げることができます。</translation>
 </phrase>
 
 <phrase>
 <original>Rendering the primary image canvas is a common bottleneck for PhotoDemon's performance.  The automatic setting is recommended, but for older PCs, you can manually select the Maximize Performance option to sacrifice quality for raw performance.</original>
-<translation>主画像キャンバスのレンダリングは、PhotoDemon のパフォーマンスの一般的なボトルネックです。  自動設定が推奨されますが、古いPCの場合、手動でパフォーマンスの最大化オプションを選択し、品質と引き換えにパフォーマンスを向上できます。</translation>
+<translation>主画像キャンバスのレンダリングは、PhotoDemon のパフォーマンスの一般的なボトルネックです。  自動設定が推奨されますが、古い PC の場合、手動でパフォーマンスの最大化オプションを選択し、品質と引き換えにパフォーマンスを向上できます。</translation>
 </phrase>
 
 <phrase>
 <original>Low compression settings require more disk space, but undo/redo operations will be faster.  High compression settings require less disk space, but undo/redo operations will be slower.  Undo data is erased when images are closed, so this setting only affects disk space while images are actively being edited.</original>
-<translation>低圧縮設定は、より多くのディスク スペースを必要としますが、アンドゥ/リドゥ操作はより速くなります。  圧縮率を高く設定すると、必要なディスク容量は少なくなりますが、アンドゥ/リドゥの処理速度は遅くなります。  元に戻すデータは画像を閉じると消去されるため、この設定がディスク容量に影響するのは、画像がアクティブに編集されている間だけです。</translation>
+<translation>低圧縮設定ではより多くのディスク容量が必要になりますが、元に戻す/やり直しの操作は高速になります。  高圧縮設定では必要なディスク容量は少なくなりますが、元に戻す/やり直しの操作は遅くなります。  画像を閉じると元に戻すデータが消去されるため、この設定は画像がアクティブに編集されている間のディスク容量にのみ影響します。</translation>
 </phrase>
 
 <phrase>
@@ -13647,7 +13646,7 @@ Are you sure you want to continue?</original>
 
 <phrase>
 <original>BPC is primarily relevant in colorimetric rendering intents, where it helps preserve detail in dark (shadow) regions of images.  For most workflows, BPC should be turned ON.</original>
-<translation>BPC は主に、画像の暗い (シャドウ) 領域のディテールを保持するのに役立つ、比色レンダリングの意図に関連しています。  ほとんどのワークフローでは、BPC をオンにする必要があります。</translation>
+<translation>BPC は主に比色レンダリング インテントに関連しており、画像の暗い (シャドウ) 領域のディテールを保持するのに役立ちます。ほとんどのワークフローでは、BPC をオンにする必要があります。</translation>
 </phrase>
 
 <phrase>
@@ -13672,17 +13671,17 @@ Are you sure you want to continue?</original>
 
 <phrase>
 <original>Because PhotoDemon is a portable application, it can only check for updates when the program is running.  By default, PhotoDemon will check for updates whenever the program is launched, but you can reduce this frequency if desired.</original>
-<translation>PhotoDemon はポータブル アプリケーションであるため、プログラムの実行時にのみアップデートを確認できます。  既定では、PhotoDemon はプログラム起動時にアップデートをチェックしますが、必要に応じてこの頻度を減らすことができます。</translation>
+<translation>PhotoDemon はポータブル アプリケーションであるため、プログラムの実行中にのみ更新を確認できます。  デフォルトでは、PhotoDemon はプログラムが起動されるたびに更新をチェックしますが、必要に応じてこの頻度を減らすことができます。</translation>
 </phrase>
 
 <phrase>
 <original>stable releases</original>
-<translation>安定リリース</translation>
+<translation>安定版リリース</translation>
 </phrase>
 
 <phrase>
 <original>stable and beta releases</original>
-<translation>安定リリースとベータ リリース</translation>
+<translation>安定版とベータ版のリリース</translation>
 </phrase>
 
 <phrase>
@@ -13692,7 +13691,7 @@ Are you sure you want to continue?</original>
 
 <phrase>
 <original>One of the best ways to support PhotoDemon is to help test new releases.  By default, PhotoDemon will suggest both stable and beta releases, but the truly adventurous can also try developer releases.  (Developer releases give you immediate access to the latest program enhancements, but you might encounter some bugs.)</original>
-<translation>PhotoDemonをサポートする最良の方法の1つは、新しいリリースのテストに協力することです。  既定では、PhotoDemon は安定リリースとベータ リリースの両方を提案しますが、本当に冒険好きな方は、開発者リリースを試すこともできます。  (開発者リリースでは、最新のプログラム拡張にすぐにアクセスできますが、バグに遭遇する可能性があります)</translation>
+<translation>PhotoDemon をサポートする最良の方法の 1 つは、新しいリリースのテストを支援することです。  デフォルトでは、PhotoDemon は安定版とベータ版の両方のリリースを提案しますが、本当に冒険好きな人は開発者版のリリースを試すこともできます。  (開発者リリースでは、プログラムの最新の機能強化にすぐにアクセスできますが、いくつかのバグが発生する可能性があります)</translation>
 </phrase>
 
 <phrase>
@@ -13704,43 +13703,43 @@ Are you sure you want to continue?</original>
 <original>You have placed PhotoDemon in a restricted system folder.  Security precautions prevent PhotoDemon from modifying this folder, so automatic updates are now disabled.  To restore them, you must move PhotoDemon to a non-admin folder, like Desktop, Documents, or Downloads.
 
 (If you leave PhotoDemon where it is, please don't forget to visit PhotoDemon.org from time to time to check for new versions.)</original>
-<translation>制限されたシステム フォルダに PhotoDemon を配置しました。  セキュリティ対策により、PhotoDemon はこのフォルダを変更できないため、自動アップデートは現在無効になっています。  復元するには、PhotoDemonをデスクトップ、ドキュメント、またはダウンロードのような非管理フォルダに移動する必要があります。
+<translation>制限されたシステム フォルダーに PhotoDemon を配置しました。  セキュリティ対策により、PhotoDemon はこのフォルダーを変更できないため、自動アップデートは現在無効になっています。  復元するには、PhotoDemonをデスクトップ、ドキュメント、またはダウンロードのような非管理フォルダーに移動する必要があります。
 
-(PhotoDemon をそのままにしておく場合、新しいバージョンをチェックするために時々 PhotoDemon.org を訪問することを忘れないでください)</translation>
+(PhotoDemon をそのままにしておく場合、時々 PhotoDemon.org を訪問して新しいバージョンをチェックすることを忘れないでください)</translation>
 </phrase>
 
 <phrase>
 <original>The developers of PhotoDemon take privacy very seriously, so no information - statistical or otherwise - is uploaded during the update process.  Updates simply involve downloading several small XML files from PhotoDemon.org. These files contain the latest software, plugin, and language version numbers. If updated versions are found, and user preferences allow, the updated files are then downloaded and patched automatically.
 
 If you still choose to disable updates, don't forget to visit PhotoDemon.org from time to time to check for new versions.</original>
-<translation>PhotoDemon の開発者は、プライバシーを非常に重要視しているため、更新処理中に統計的またはその他の情報がアップロードされることはありません。  アップデートは、PhotoDemon.org からいくつかの小さな XML ファイルをダウンロードするだけです。これらのファイルは、最新のソフトウェア、プラグイン、および言語バージョン番号を含んでいます。更新されたバージョンが発見され、ユーザー設定が許可する場合、更新されたファイルは自動的にダウンロードされ、パッチが適用されます。
+<translation>PhotoDemon の開発者はプライバシーを非常に重視しているため、更新プロセス中に統計情報またはその他の情報がアップロードされることはありません。  アップデートには、PhotoDemon.org からいくつかの小さな XML ファイルをダウンロードするだけです。  これらのファイルには、最新のソフトウェア、プラグイン、言語のバージョン番号が含まれています。  更新されたバージョンが見つかり、ユーザー設定で許可されている場合は、更新されたファイルがダウンロードされ、自動的にパッチが適用されます。
 
-アップデートを無効にする場合、時々 PhotoDemon.org を訪問し、新しいバージョンをチェックすることを忘れないでください。</translation>
+それでもアップデートを無効にすることを選択する場合は、時々 PhotoDemon.org にアクセスして新しいバージョンをチェックすることを忘れないでください。</translation>
 </phrase>
 
 <phrase>
-<original>In developer builds, debug data is automatically logged to the program's \Data\Debug folder.  If you encounter bugs in a stable release, please manually activate this setting.  This will help developers resolve your problem.</original>
-<translation>開発者用ビルドでは、デバッグ データは自動的にプログラムの一時フォルダに記録されます。  安定版リリースでバグに遭遇した場合は、手動でこの設定を有効にしてください。  これは、開発者があなたの問題を解決するのに役立ちます。</translation>
+<original>In developer builds, debug data is automatically logged to the program's &#92;Data&#92;Debug folder.  If you encounter bugs in a stable release, please manually activate this setting.  This will help developers resolve your problem.</original>
+<translation>開発者ビルドでは、デバッグ データはプログラムの &#92;Data&#92;Debug フォルダーに自動的に記録されます。  安定版リリースでバグが発生した場合は、この設定を手動で有効にしてください。  これは開発者が問題を解決するのに役立ちます。</translation>
 </phrase>
 
 <phrase>
 <original>When using Remote Desktop or a VM (Virtual Machine), high-resolution mouse input may not work correctly.  This is a long-standing Windows bug.  In these situations, you can use this setting to restore correct mouse behavior.</original>
-<translation>リモート デスクトップまたは VM (仮想マシン) を使用している場合、高解像度のマウス入力が正しく動作しないことがあります。  これは Windows の長年のバグです。  このような状況では、この設定を使用して正しいマウス動作を復元できます。</translation>
+<translation>リモート デスクトップまたは VM (仮想マシン) を使用する場合、高解像度のマウス入力が正しく動作しない場合があります。  これは Windows の長年のバグです。  このような状況では、この設定を使用してマウスの正しい動作を復元できます。</translation>
 </phrase>
 
 <phrase>
 <original>current PhotoDemon memory usage</original>
-<translation>現在の PhotoDemon のメモリ使用量</translation>
+<translation>現在の PhotoDemon のメモリー使用量</translation>
 </phrase>
 
 <phrase>
 <original>max PhotoDemon memory usage this session</original>
-<translation>このセッションにおける PhotoDemon の最大メモリ使用量</translation>
+<translation>このセッションでの PhotoDemon の最大メモリー使用量</translation>
 </phrase>
 
 <phrase>
 <original>Click to select a new temporary folder.</original>
-<translation>クリックして新しい一時フォルダを選択します。</translation>
+<translation>クリックして新しい一時フォルダーを選択します。</translation>
 </phrase>
 
 <phrase>
@@ -13750,12 +13749,12 @@ If you still choose to disable updates, don't forget to visit PhotoDemon.org fro
 
 <phrase>
 <original>WARNING: this folder is invalid (access prohibited).  Please provide a valid folder.  If a new folder is not provided, PhotoDemon will use the system temp folder.</original>
-<translation>警告: このフォルダは無効です (アクセス禁止)。  有効なフォルダを指定してください。  新しいフォルダが提供されない場合、PhotoDemon はシステムの一時フォルダを使用します。</translation>
+<translation>警告: このフォルダーは無効です (アクセス禁止)。有効なフォルダーを指定してください。  新しいフォルダーが指定されていない場合、PhotoDemon はシステムの一時フォルダーを使用します。</translation>
 </phrase>
 
 <phrase>
 <original>This new temporary folder location will not take effect until you restart the program.</original>
-<translation>この新しい一時フォルダの場所は、プログラムを再起動するまで有効になりません。</translation>
+<translation>この新しい一時フォルダーの場所は、プログラムを再起動するまで有効になりません。</translation>
 </phrase>
 
 <!-- Tools_Options.frm contains 190 phrases. 55 were duplicates of existing phrases, so only 135 new phrases were written to file. -->
@@ -13777,12 +13776,12 @@ If you still choose to disable updates, don't forget to visit PhotoDemon.org fro
 
 <phrase>
 <original>GOOD</original>
-<translation>GOOD</translation>
+<translation>良い</translation>
 </phrase>
 
 <phrase>
 <original>library folder</original>
-<translation>ライブラリのフォルダ</translation>
+<translation>ライブラリのフォルダー</translation>
 </phrase>
 
 <phrase>


### PR DESCRIPTION
Added Japanese localization.

I translated about 20% of it manually for short words, then did a batch translation at DeepL. After I reviewed the whole thing and manually corrected most of the puzzling translations and notational quirks, which are not perfect, but most of them are corrected.

I am currently reviewing it further, both visually and with Google Translate and ChatGPT GPT-4o, looking for unnatural or incorrect translations, and will review as much as possible during July 11 and I will lift the draft flag. 

See also #572

![image](https://github.com/tannerhelland/PhotoDemon/assets/36189684/bdc933b7-f5bd-433d-bad1-3f4733dd0ec1)
